### PR TITLE
[15.0][FIX] repair_stock_move: lot in stock move line for product to repair

### DIFF
--- a/repair_stock_move/models/stock_move.py
+++ b/repair_stock_move/models/stock_move.py
@@ -62,4 +62,6 @@ class StockMove(models.Model):
         )
         if self.repair_line_id and self.repair_line_id.lot_id:
             vals["lot_id"] = self.repair_line_id.lot_id.id
+        elif self.repair_id and self.repair_id.lot_id:
+            vals["lot_id"] = self.repair_id.lot_id.id
         return vals


### PR DESCRIPTION
Create a repair order for a product tracked by lots and try to end the repair. The stock move line will never get the lot_id:

![lot_missing_final_product](https://github.com/OCA/repair/assets/19620251/1ca23137-7051-4132-ba8b-04b7559a183c)


@ForgeFlow