### PR TITLE
[15.0][FIX] repair_refurbish: link refurbish move to the repair order

### DIFF
--- a/repair_refurbish/models/repair.py
+++ b/repair_refurbish/models/repair.py
@@ -49,6 +49,7 @@ class RepairOrder(models.Model):
             "product_uom_qty": self.product_qty,
             "partner_id": self.address_id and self.address_id.id or False,
             "location_id": self.location_dest_id.id,
+            "repair_id": self.id,
             "location_dest_id": self.refurbish_location_dest_id.id,
             "move_line_ids": [
                 (


### PR DESCRIPTION
Otherwise the refurbished stock move is not linked to the repair order and the button "Product Moves" in repair orders will not show the refurbished move.

![product_moves_repair](https://github.com/OCA/repair/assets/19620251/c534a546-5caa-4fe6-81a7-033f9bf873c1)


cc @ForgeFlow