### PR TITLE
[15.0][ADD] repair_security

### DIFF
--- a/repair_security/__init__.py
+++ b/repair_security/__init__.py
@@ -1,0 +1,1 @@
+from .hook import post_init_hook

--- a/repair_security/__manifest__.py
+++ b/repair_security/__manifest__.py
@@ -15,4 +15,5 @@
         "security/ir.model.access.csv",
         "views/repair_views.xml",
     ],
+    "post_init_hook": "post_init_hook",
 }

--- a/repair_security/__manifest__.py
+++ b/repair_security/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2020 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Repair Security",
+    "summary": "Create security groups for Repair",
+    "version": "15.0.1.0.0",
+    "category": "Manufacturing",
+    "website": "https://github.com/OCA/repair",
+    "author": "ForgeFlow S.L., Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": ["repair"],
+    "data": [
+        "security/repair_security.xml",
+        "security/ir.model.access.csv",
+        "views/repair_views.xml",
+    ],
+}

--- a/repair_security/hook.py
+++ b/repair_security/hook.py
@@ -1,0 +1,12 @@
+from odoo import SUPERUSER_ID
+from odoo.api import Environment
+
+
+def post_init_hook(cr, _):
+    env = Environment(cr, SUPERUSER_ID, {})
+    # Giving Repair Admin access to match the previous permissions.
+    env.ref("repair_security.group_repair_manager").write(
+        {
+            "users": [(6, 0, env.ref("stock.group_stock_user").users.ids)],
+        }
+    )

--- a/repair_security/readme/CONTRIBUTORS.rst
+++ b/repair_security/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* David Jiménez <david.jimenez@forgeflow.com>

--- a/repair_security/readme/DESCRIPTION.rst
+++ b/repair_security/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module adds security groups fro the Repair App to make it more configurable and independent of Stock.

--- a/repair_security/security/ir.model.access.csv
+++ b/repair_security/security/ir.model.access.csv
@@ -1,0 +1,13 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_repair_fee_user,Repair Fee user,repair.model_repair_fee,repair_security.group_repair_user,1,0,0,0
+access_repair_fee_manager,Repair Fee manager,repair.model_repair_fee,repair_security.group_repair_manager,1,1,1,1
+access_repair_user,Repair user,repair.model_repair_order,repair_security.group_repair_user,1,1,0,0
+access_repair_manager,Repair manager,repair.model_repair_order,repair_security.group_repair_manager,1,1,1,1
+access_repair_tag_user,Repair Tags user,repair.model_repair_tags,repair_security.group_repair_user,1,0,0,0
+access_repair_tag_manager,Repair Tags user,repair.model_repair_tags,repair_security.group_repair_manager,1,1,1,1
+access_repair_line_user,repair.line user,repair.model_repair_line,repair_security.group_repair_user,1,1,0,0
+access_repair_line_manager,repair.line user,repair.model_repair_line,repair_security.group_repair_manager,1,1,1,1
+access_account_tax_user,account.tax,account.model_account_tax,repair_security.group_repair_user,1,0,0,0
+access_account_tax_manager,account.tax,account.model_account_tax,repair_security.group_repair_manager,1,0,0,0
+access_repair_order_make_invoice_manager,access.repair.order.make_invoice,repair.model_repair_order_make_invoice,repair_security.group_repair_manager,1,1,1,1
+access_stock_warn_insufficient_qty_repair_manager,access.stock.warn.insufficient.qty.repair,repair.model_stock_warn_insufficient_qty_repair,repair_security.group_repair_manager,1,1,1,1

--- a/repair_security/security/repair_security.xml
+++ b/repair_security/security/repair_security.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+
+    <function model="ir.model.access" name="write">
+        <value
+            eval="[ref('repair.access_repair_fee_user'), ref('repair.access_repair_user'), ref('repair.access_repair_tag_user'), ref('repair.access_repair_line_user'), ref('repair.access_account_tax_user'), ref('repair.access_repair_order_make_invoice'), ref('repair.access_stock_warn_insufficient_qty_repair')]"
+        />
+        <value eval="{'active': False }" />
+    </function>
+
+    <record model="ir.module.category" id="module_category_repair">
+        <field name="name">Repair</field>
+        <field name="sequence">25</field>
+    </record>
+
+    <record id="group_repair_user" model="res.groups">
+        <field name="name">User</field>
+        <field name="category_id" ref="repair_security.module_category_repair" />
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]" />
+    </record>
+    <record id="group_repair_manager" model="res.groups">
+        <field name="name">Administrator</field>
+        <field name="category_id" ref="repair_security.module_category_repair" />
+        <field name="implied_ids" eval="[(4, ref('group_repair_user'))]" />
+        <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+    </record>
+
+</odoo>

--- a/repair_security/views/repair_views.xml
+++ b/repair_security/views/repair_views.xml
@@ -1,0 +1,9 @@
+<odoo>
+
+    <record model="ir.ui.menu" id="repair.menu_repair_order">
+        <field
+            name="groups_id"
+            eval="[(6, 0, [ref('repair_security.group_repair_user')])]"
+        />
+  </record>
+</odoo>

--- a/setup/repair_security/odoo/addons/repair_security
+++ b/setup/repair_security/odoo/addons/repair_security
@@ -1,0 +1,1 @@
+../../../../repair_security

--- a/setup/repair_security/setup.py
+++ b/setup/repair_security/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
The access rights for the repair app are related with the Inventory app. This forces to have your stock user having access to the Repair section (being able to do all the flow).

This module archives the old access rights and adds a Repair specific ones. 

Now, the Repair User can only read and do the simple flow (start and end a repair and confirm the repairs with no conflict ).

The manager is the one in charge of resolving the conflicts, creating the invoices, etc. 

@ForgeFlow