### PR TITLE
[15.0][FIX] repair_refurbish: refurbish should not be the default option even if there is a refurbish product

### DIFF
--- a/repair_refurbish/models/repair.py
+++ b/repair_refurbish/models/repair.py
@@ -24,12 +24,6 @@ class RepairOrder(models.Model):
         string="Refurbished Inventory Move", comodel_name="stock.move"
     )
 
-    @api.onchange("product_id")
-    def onchange_product_id(self):
-        res = super().onchange_product_id()
-        self.to_refurbish = True if self.product_id.refurbish_product_id else False
-        return res
-
     @api.onchange("to_refurbish", "product_id")
     def _onchange_to_refurbish(self):
         if self.to_refurbish:

--- a/repair_refurbish/tests/test_repair_refurbish.py
+++ b/repair_refurbish/tests/test_repair_refurbish.py
@@ -55,7 +55,8 @@ class TestMrpMtoWithStock(TransactionCase):
             }
         )
         repair.onchange_product_id()
-        self.assertTrue(repair.to_refurbish)
+        self.assertFalse(repair.to_refurbish)
+        repair.to_refurbish = True
         repair._onchange_to_refurbish()
         self.assertEqual(repair.refurbish_location_dest_id, self.customer_location)
         self.assertEqual(repair.location_dest_id, self.product.property_stock_refurbish)


### PR DESCRIPTION
A product may have a refurbished version. But that does not mean all the repairs should be refurbished. In many cases the product is good condition and the product in stock can be the same as the original. i think the default should be the normal case for all products and in case of refurbish it has to be explicitly added.

cc @ForgeFlow