### PR TITLE
[16.0][FIX] repair_picking_after_done: get picking type

### DIFF
--- a/repair_picking_after_done/models/repair.py
+++ b/repair_picking_after_done/models/repair.py
@@ -7,7 +7,7 @@ from odoo import _, fields, models
 class Repair(models.Model):
     _inherit = "repair.order"
 
-    picking_ids = fields.Many2many("stock.picking", string="Transfers")
+    picking_ids = fields.Many2many("stock.picking", string="Transfers", copy=False)
     remaining_quantity = fields.Float(
         "Remaining quantity to be transferred", compute="_compute_remaining_quantity"
     )

--- a/repair_picking_after_done/wizards/repair_move_transfer.py
+++ b/repair_picking_after_done/wizards/repair_move_transfer.py
@@ -20,14 +20,7 @@ class MrpInventoryProcure(models.TransientModel):
 
     def _get_picking_type(self):
         self.ensure_one()
-        warehouse = (
-            self.env["stock.warehouse"]
-            .search([])
-            .filtered(
-                lambda l: self.repair_order_id.location_id.id
-                in l.view_location_id.child_ids.ids
-            )
-        )
+        warehouse = self.repair_order_id.location_id.warehouse_id
         return warehouse.int_type_id
 
     def _prepare_picking_vals(self):


### PR DESCRIPTION
This is how Odoo does it: https://github.com/odoo/odoo/blob/16.0/addons/repair/models/repair.py#L195

Otherwise granchildren locations were not considered and the warehouse is not found.

Edit: also fixed the copy attribute in picking_ids field. We don't want the pickings to be copied to the copied repair order.

cc @ForgeFlow