### PR TITLE
[16.0][FIX] repair_type: remove repair_type_id required on repair view

### DIFF
--- a/repair_type/views/repair.xml
+++ b/repair_type/views/repair.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="repair.view_repair_order_form" />
         <field name="arch" type="xml">
             <field name="product_id" position="after">
-                 <field name="repair_type_id" attrs="{'required': True}" />
+                 <field name="repair_type_id" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Repair type should not be required on repair view