### PR TITLE
[15.0][IMP] repair_refurbish_repair_stock_move: allow setting a repair order "to refurbish" in the middle of the process

### DIFF
--- a/repair_refurbish/models/repair.py
+++ b/repair_refurbish/models/repair.py
@@ -38,6 +38,7 @@ class RepairOrder(models.Model):
     def _get_refurbish_stock_move_dict(self):
         return {
             "name": self.name,
+            "origin": self.name,
             "product_id": self.refurbish_product_id.id,
             "product_uom": self.product_uom.id or self.refurbish_product_id.uom_id.id,
             "product_uom_qty": self.product_qty,

--- a/repair_refurbish_repair_stock_move/tests/__init__.py
+++ b/repair_refurbish_repair_stock_move/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_repair_refurbish

--- a/repair_refurbish_repair_stock_move/tests/test_repair_refurbish.py
+++ b/repair_refurbish_repair_stock_move/tests/test_repair_refurbish.py
@@ -1,0 +1,96 @@
+# Copyright 2024 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestMrpMtoWithStock(TransactionCase):
+    def setUp(self, *args, **kwargs):
+        super(TestMrpMtoWithStock, self).setUp(*args, **kwargs)
+        self.repair_obj = self.env["repair.order"]
+        self.repair_line_obj = self.env["repair.line"]
+        self.product_obj = self.env["product.product"]
+        self.move_obj = self.env["stock.move"]
+
+        self.stock_location_stock = self.env.ref("stock.stock_location_stock")
+        self.customer_location = self.env.ref("stock.stock_location_customers")
+        self.refurbish_loc = self.env.ref("repair_refurbish.stock_location_refurbish")
+
+        self.refurbish_product = self.product_obj.create(
+            {"name": "Refurbished Awesome Screen", "type": "product"}
+        )
+        self.product = self.product_obj.create(
+            {
+                "name": "Awesome Screen",
+                "type": "product",
+                "refurbish_product_id": self.refurbish_product.id,
+            }
+        )
+        self.material = self.product_obj.create({"name": "Materials", "type": "consu"})
+        self.material2 = self.product_obj.create(
+            {"name": "Materials", "type": "product"}
+        )
+        self._update_product_qty(self.product, self.stock_location_stock, 10.0)
+
+    def _update_product_qty(self, product, location, quantity):
+        self.env["stock.quant"].create(
+            {
+                "location_id": location.id,
+                "product_id": product.id,
+                "inventory_quantity": quantity,
+            }
+        ).action_apply_inventory()
+        return quantity
+
+    def test_01_repair_refurbish(self):
+        """Tests that the refusrbih move is created when
+        the repair is marked as to refurbish AFTER
+        being validated"""
+        repair = self.repair_obj.create(
+            {
+                "product_id": self.product.id,
+                "product_qty": 3.0,
+                "product_uom": self.product.uom_id.id,
+                "location_dest_id": self.customer_location.id,
+                "location_id": self.stock_location_stock.id,
+            }
+        )
+        repair.onchange_product_id()
+        # Complete repair:
+        repair.action_validate()
+        repair.action_repair_start()
+        # Make it "to refurbish" in the middle
+        repair.refurbish_product_id = self.refurbish_product
+        repair.refurbish_location_dest_id = repair.location_dest_id
+        repair.location_dest_id = repair.product_id.property_stock_refurbish
+        repair.to_refurbish = True
+        repair.action_repair_end()
+        moves = self.move_obj.search(
+            [("reference", "=", repair.name), ("state", "!=", "cancel")]
+        )
+        self.assertEqual(len(moves), 2)
+        for m in moves:
+            self.assertEqual(m.state, "done")
+            if m.product_id == self.product:
+                self.assertEqual(m.location_id, self.stock_location_stock)
+                self.assertEqual(m.location_dest_id, self.refurbish_loc)
+                self.assertEqual(
+                    m.mapped("move_line_ids.location_id"), self.stock_location_stock
+                )
+                self.assertEqual(
+                    m.mapped("move_line_ids.location_dest_id"), self.refurbish_loc
+                )
+            elif m.product_id == self.refurbish_product:
+                # check the refurbish moves are created anyway
+                self.assertEqual(m.location_id, self.refurbish_loc)
+                self.assertEqual(m.location_dest_id, self.customer_location)
+                self.assertEqual(
+                    m.mapped("move_line_ids.location_id"), self.refurbish_loc
+                )
+                self.assertEqual(
+                    m.mapped("move_line_ids.location_dest_id"), self.customer_location
+                )
+            else:
+                self.assertTrue(
+                    False, "Unexpected product: %s" % m.product_id.display_name
+                )

--- a/repair_stock_move/models/repair_order.py
+++ b/repair_stock_move/models/repair_order.py
@@ -77,8 +77,7 @@ class RepairOrder(models.Model):
         move_dict = self._prepare_repair_stock_move()
         return self.env["stock.move"].create(move_dict)
 
-    def action_repair_confirm(self):
-        res = super().action_repair_confirm()
+    def _create_and_confirm_stock_moves(self):
         for repair in self:
             moves = self.env["stock.move"]
             for operation in repair.operations:
@@ -88,6 +87,11 @@ class RepairOrder(models.Model):
             move = repair._create_repair_stock_move()
             repair.move_id = move
         self.mapped("stock_move_ids")._action_confirm()
+        return self.mapped("stock_move_ids")
+
+    def action_repair_confirm(self):
+        res = super().action_repair_confirm()
+        self._create_and_confirm_stock_moves()
         return res
 
     def action_assign(self):


### PR DESCRIPTION
This fixes the case where the stock moves are already created but in the middle the user decides the repair will be refurbish.

Before this fix the stock moves are already created and they are not valid for the new approach. Also
the repair refurbish move is not created.

The solution consist of cancelling existing moves and recreating them.

It also covers the case when the repair passes from "to refurbish" to a normal repair.

This also includes a needed improvement in dependent module:

`[IMP] repair_stock_move: do the creation of stock moves in separate method to improve inheritability
`

Additionally, added a small improvement in  repair_refurbish:

`[IMP] repair_refurbish: the source document of the refurbish stock move should be the repair order, the other stock moves related to the repair are already with that source document`


cc @ForgeFlow