### PR TITLE
[15.0][FIX] repair_stock_move: proper main lot management & default location for remove operations

### DIFF
--- a/repair_stock_move/models/repair_line.py
+++ b/repair_stock_move/models/repair_line.py
@@ -45,10 +45,12 @@ class RepairLine(models.Model):
             res.move_id = move
         return res
 
-    @api.onchange("product_id")
-    def _onchange_location(self):
-        if self.state == "draft":
+    @api.onchange("type")
+    def onchange_operation_type(self):
+        res = super().onchange_operation_type()
+        if self.state == "draft" and self.type == "add":
             self.location_id = self.repair_id.location_id
+        return res
 
     # TODO: write qty - update stock move.
     # TODO: default repair location in repair lines.

--- a/repair_stock_move/models/stock_move.py
+++ b/repair_stock_move/models/stock_move.py
@@ -24,6 +24,8 @@ class StockMove(models.Model):
     ):
         if self.repair_line_id and self.repair_line_id.lot_id:
             lot_id = self.repair_line_id.lot_id
+        if self.repair_id and not self.repair_line_id and self.repair_id.lot_id:
+            lot_id = self.repair_id.lot_id
 
         return super()._get_available_quantity(
             location_id,
@@ -46,6 +48,8 @@ class StockMove(models.Model):
     ):
         if self.repair_line_id and self.repair_line_id.lot_id:
             lot_id = self.repair_line_id.lot_id
+        if self.repair_id and not self.repair_line_id and self.repair_id.lot_id:
+            lot_id = self.repair_id.lot_id
         return super(StockMove, self)._update_reserved_quantity(
             need,
             available_quantity,
@@ -62,6 +66,6 @@ class StockMove(models.Model):
         )
         if self.repair_line_id and self.repair_line_id.lot_id:
             vals["lot_id"] = self.repair_line_id.lot_id.id
-        elif self.repair_id and self.repair_id.lot_id:
+        elif self.repair_id and not self.repair_line_id and self.repair_id.lot_id:
             vals["lot_id"] = self.repair_id.lot_id.id
         return vals


### PR DESCRIPTION
Two fixes added with this PR:

**(1) Proper main lot management**:
When product to be repaired has tracking two different issues could be raised:
* If a repair line hasn't lot filled (because e.g. product has no tracking), lot/serial for repaired product is used for lines reservation and an error is raised, due to incompatibility with the line product, when this product is untracked.
* When creating stock move reservation for repaired product, move line is properly created, but sometimes stock quant is incorrectly updated, e.g. if there's an older lot available, because the lot was not properly marked during reservation process.    

This commit fixes both issues and fixes #39 

**(2) Default repair line source location for remove operations**:
With this fix, for "remove" repair lines repair location is not used as default source location, that is preserved for "add" operations.

--------

@AaronHForgeFlow @DavidJForgeFlow could you review? If needed, I'd split this in two different PRs.