### PR TITLE
[17.0][FIX] repair_type: Remove duplicated destination location for added parts

### DIFF
--- a/repair_type/README.rst
+++ b/repair_type/README.rst
@@ -28,10 +28,10 @@ Repair Type
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module adds the source location from removing and recycling
-components. If we select the both locations on stock picking type when
-you select that in a Repair Order, Odoo will automatically set that in
-stock moves for that components.
+This module adds support for source locations when adding, removing, or
+recycling components. If you specify any of these types in a Repair
+Order, Odoo will automatically apply the corresponding locations from
+the related stock picking type to the stock moves.
 
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
@@ -46,10 +46,11 @@ stock moves for that components.
 Usage
 =====
 
-Set stock picking type for repairs and select source locations for
-removing and recycling components. Afterwards selecting that stock
-picking type on a Repair Order will automatically put that source
-location on stock moves of that components.
+-  Set the stock picking type for repairs and define source locations
+   for adding, removing and recycling components.
+-  When you select this stock picking type in a Repair Order, Odoo will
+   automatically assign the specified source locations to the stock
+   moves for the respective components.
 
 Bug Tracker
 ===========

--- a/repair_type/i18n/es.po
+++ b/repair_type/i18n/es.po
@@ -6,25 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-27 13:31+0000\n"
-"PO-Revision-Date: 2024-06-27 13:31+0000\n"
+"POT-Creation-Date: 2024-11-27 15:14+0000\n"
+"PO-Revision-Date: 2024-11-27 15:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
 #. module: repair_type
-#: model:ir.model.fields,field_description:repair_type.field_stock_picking_type__default_add_location_dest_id
-msgid "Default Add Destination Location"
-msgstr ""
-
-#. module: repair_type
 #: model:ir.model.fields,field_description:repair_type.field_stock_picking_type__default_add_location_src_id
 msgid "Default Add Source Location"
-msgstr ""
+msgstr "Ubicación de origen por defecto para añadir"
 
 #. module: repair_type
 #: model:ir.model.fields,field_description:repair_type.field_stock_picking_type__default_recycle_location_src_id
@@ -39,7 +33,12 @@ msgstr "Ubicación de origen por defecto para eliminar"
 #. module: repair_type
 #: model:ir.model,name:repair_type.model_stock_picking_type
 msgid "Picking Type"
-msgstr "Tipo de recolección"
+msgstr "Tipo de albarán"
+
+#. module: repair_type
+#: model:ir.model,name:repair_type.model_repair_order
+msgid "Repair Order"
+msgstr "Orden de reparación"
 
 #. module: repair_type
 #: model:ir.model,name:repair_type.model_stock_move
@@ -47,18 +46,13 @@ msgid "Stock Move"
 msgstr "Movimiento de stock"
 
 #. module: repair_type
-#: model:ir.model.fields,help:repair_type.field_stock_picking_type__default_add_location_dest_id
-msgid ""
-"This is the default add destination location when you create a repair order "
-"with this operation type."
-msgstr ""
-
-#. module: repair_type
 #: model:ir.model.fields,help:repair_type.field_stock_picking_type__default_add_location_src_id
 msgid ""
 "This is the default add source location when you create a repair order with "
 "this operation type."
 msgstr ""
+"Esta es la ubicación de origen por defecto para añadir cuando cree una orden"
+" de reparación con este tipo de operación."
 
 #. module: repair_type
 #: model:ir.model.fields,help:repair_type.field_stock_picking_type__default_recycle_location_src_id
@@ -66,8 +60,8 @@ msgid ""
 "This is the default recycle source location when you create a repair order "
 "with this operation type."
 msgstr ""
-"Esta es la ubicación de origen por defecto para el reciclaje cuando cree una "
-"orden de reparación con este tipo de operación."
+"Esta es la ubicación de origen por defecto para el reciclaje cuando cree una"
+" orden de reparación con este tipo de operación."
 
 #. module: repair_type
 #: model:ir.model.fields,help:repair_type.field_stock_picking_type__default_remove_location_src_id

--- a/repair_type/i18n/hr.po
+++ b/repair_type/i18n/hr.po
@@ -4,23 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2022-08-22 14:07+0000\n"
-"Last-Translator: Bole <bole@dajmi5.com>\n"
-"Language-Team: none\n"
-"Language: hr\n"
+"POT-Creation-Date: 2024-11-27 15:16+0000\n"
+"PO-Revision-Date: 2024-11-27 15:16+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 4.3.2\n"
-
-#. module: repair_type
-#: model:ir.model.fields,field_description:repair_type.field_stock_picking_type__default_add_location_dest_id
-msgid "Default Add Destination Location"
-msgstr ""
+"Plural-Forms: \n"
 
 #. module: repair_type
 #: model:ir.model.fields,field_description:repair_type.field_stock_picking_type__default_add_location_src_id
@@ -40,19 +33,17 @@ msgstr ""
 #. module: repair_type
 #: model:ir.model,name:repair_type.model_stock_picking_type
 msgid "Picking Type"
-msgstr ""
+msgstr "Vrsta dokumenta"
+
+#. module: repair_type
+#: model:ir.model,name:repair_type.model_repair_order
+msgid "Repair Order"
+msgstr "Nalog za popravak"
 
 #. module: repair_type
 #: model:ir.model,name:repair_type.model_stock_move
 msgid "Stock Move"
-msgstr ""
-
-#. module: repair_type
-#: model:ir.model.fields,help:repair_type.field_stock_picking_type__default_add_location_dest_id
-msgid ""
-"This is the default add destination location when you create a repair order "
-"with this operation type."
-msgstr ""
+msgstr "Skladišni prijenos"
 
 #. module: repair_type
 #: model:ir.model.fields,help:repair_type.field_stock_picking_type__default_add_location_src_id
@@ -74,57 +65,3 @@ msgid ""
 "This is the default remove source location when you create a repair order "
 "with this operation type."
 msgstr ""
-
-#~ msgid "Created by"
-#~ msgstr "Kreirao"
-
-#~ msgid "Created on"
-#~ msgstr "Kreirano"
-
-#~ msgid "Dest. Location"
-#~ msgstr "Odredišna lokacija"
-
-#~ msgid "Destination Location Add Component"
-#~ msgstr "Dodaj komponentu na odredišnu lokaciju"
-
-#~ msgid "Destination Location Remove Component"
-#~ msgstr "Ukloni komponentu sa odredišne lokacije"
-
-#~ msgid "Display Name"
-#~ msgstr "Naziv"
-
-#~ msgid "ID"
-#~ msgstr "ID"
-
-#~ msgid "Last Modified on"
-#~ msgstr "Zadnje modificirano"
-
-#~ msgid "Last Updated by"
-#~ msgstr "Zadnje ažurirano"
-
-#~ msgid "Location"
-#~ msgstr "Lokacija"
-
-#~ msgid "Repair Line (parts)"
-#~ msgstr "Stavka popravka (dijelovi)"
-
-#~ msgid "Repair Order"
-#~ msgstr "Nalog za popravak"
-
-#~ msgid "Repair Type"
-#~ msgstr "Vrsta popravka"
-
-#~ msgid "Repair Type Name"
-#~ msgstr "Naziv vrste popravka"
-
-#~ msgid "Repair Types"
-#~ msgstr "Vrste popravaka"
-
-#~ msgid "Repair types"
-#~ msgstr "Vrste popravaka"
-
-#~ msgid "Source Location"
-#~ msgstr "Izvorišna lokacija"
-
-#~ msgid "Destination Location"
-#~ msgstr "Odredišna lokacija"

--- a/repair_type/i18n/it.po
+++ b/repair_type/i18n/it.po
@@ -4,22 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-08-22 10:06+0000\n"
-"Last-Translator: mymage <stefano.consolaro@mymage.it>\n"
-"Language-Team: none\n"
-"Language: it\n"
+"POT-Creation-Date: 2024-11-27 15:17+0000\n"
+"PO-Revision-Date: 2024-11-27 15:17+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.6.2\n"
-
-#. module: repair_type
-#: model:ir.model.fields,field_description:repair_type.field_stock_picking_type__default_add_location_dest_id
-msgid "Default Add Destination Location"
-msgstr "Aggiungi ubicazione destinazione in modo predefinito"
+"Plural-Forms: \n"
 
 #. module: repair_type
 #: model:ir.model.fields,field_description:repair_type.field_stock_picking_type__default_add_location_src_id
@@ -39,21 +33,17 @@ msgstr "Rimuovi ubicazione origine in modo predefinito"
 #. module: repair_type
 #: model:ir.model,name:repair_type.model_stock_picking_type
 msgid "Picking Type"
-msgstr "Tipo prelievo"
+msgstr "Tipologia prelievo"
+
+#. module: repair_type
+#: model:ir.model,name:repair_type.model_repair_order
+msgid "Repair Order"
+msgstr "Ordine di riparazione"
 
 #. module: repair_type
 #: model:ir.model,name:repair_type.model_stock_move
 msgid "Stock Move"
 msgstr "Movimento di magazzino"
-
-#. module: repair_type
-#: model:ir.model.fields,help:repair_type.field_stock_picking_type__default_add_location_dest_id
-msgid ""
-"This is the default add destination location when you create a repair order "
-"with this operation type."
-msgstr ""
-"Questa è la destinazione predefinita aggiunta quando si crea un ordine di "
-"riparazione con questo tipo di operazione."
 
 #. module: repair_type
 #: model:ir.model.fields,help:repair_type.field_stock_picking_type__default_add_location_src_id
@@ -81,78 +71,3 @@ msgid ""
 msgstr ""
 "Questa è l'ubicazione rimozione predefinita aggiunta quando si crea un "
 "ordine di riparazione con questo tipo operazione."
-
-#~ msgid "Created by"
-#~ msgstr "Creato da"
-
-#~ msgid "Created on"
-#~ msgstr "Creato il"
-
-#~ msgid "Dest. Location"
-#~ msgstr "Ubicazione dest."
-
-#~ msgid "Destination Location Add Component"
-#~ msgstr "Aggiungi componente ubicazione destinazione"
-
-#~ msgid "Destination Location Remove Component"
-#~ msgstr "Rimuovi componente ubicazione destinazione"
-
-#~ msgid "Display Name"
-#~ msgstr "Nome visualizzato"
-
-#~ msgid "ID"
-#~ msgstr "ID"
-
-#~ msgid "Last Modified on"
-#~ msgstr "Ultima modifica il"
-
-#~ msgid "Last Updated by"
-#~ msgstr "Ultimo aggiornamento di"
-
-#~ msgid "Last Updated on"
-#~ msgstr "Ultimo aggiornamento il"
-
-#~ msgid "Location"
-#~ msgstr "Ubicazione"
-
-#~ msgid "Repair Line (parts)"
-#~ msgstr "Riga riparazione (componenti)"
-
-#~ msgid "Repair Order"
-#~ msgstr "Ordine di riparazione"
-
-#~ msgid "Repair Type"
-#~ msgstr "Tipo riparazione"
-
-#~ msgid "Repair Type Name"
-#~ msgstr "Nome tipo riparazione"
-
-#~ msgid "Repair Types"
-#~ msgstr "Tipi riparazione"
-
-#~ msgid "Repair types"
-#~ msgstr "Tipi riparazione"
-
-#~ msgid "Source Location"
-#~ msgstr "Ubicazione di origine"
-
-#~ msgid "Source Location Add Component"
-#~ msgstr "Aggiungi componente ubicazione origine"
-
-#~ msgid "Source Location Remove Component"
-#~ msgstr "Rimuovi componente ubicazione origine"
-
-#~ msgid ""
-#~ "This is the location where the part of the product to add is located."
-#~ msgstr ""
-#~ "Questa è l'ubicazione dove si trova il componenti del prodotto da "
-#~ "aggiungere."
-
-#~ msgid ""
-#~ "This is the location where the part of the product to remove is located."
-#~ msgstr ""
-#~ "Questa è l'ubicazione dove si trava il componente del prodotto da "
-#~ "rimuovere."
-
-#~ msgid "This is the location where the product to repair is located."
-#~ msgstr "Questa è l'ubicazione dove si trova il prodotto da riparare."

--- a/repair_type/i18n/repair_type.pot
+++ b/repair_type/i18n/repair_type.pot
@@ -6,17 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-27 15:16+0000\n"
+"PO-Revision-Date: 2024-11-27 15:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
-
-#. module: repair_type
-#: model:ir.model.fields,field_description:repair_type.field_stock_picking_type__default_add_location_dest_id
-msgid "Default Add Destination Location"
-msgstr ""
 
 #. module: repair_type
 #: model:ir.model.fields,field_description:repair_type.field_stock_picking_type__default_add_location_src_id
@@ -39,15 +36,13 @@ msgid "Picking Type"
 msgstr ""
 
 #. module: repair_type
-#: model:ir.model,name:repair_type.model_stock_move
-msgid "Stock Move"
+#: model:ir.model,name:repair_type.model_repair_order
+msgid "Repair Order"
 msgstr ""
 
 #. module: repair_type
-#: model:ir.model.fields,help:repair_type.field_stock_picking_type__default_add_location_dest_id
-msgid ""
-"This is the default add destination location when you create a repair order "
-"with this operation type."
+#: model:ir.model,name:repair_type.model_stock_move
+msgid "Stock Move"
 msgstr ""
 
 #. module: repair_type

--- a/repair_type/models/stock_move.py
+++ b/repair_type/models/stock_move.py
@@ -16,7 +16,7 @@ class StockMove(models.Model):
             ):
                 res = (
                     self.repair_id.picking_type_id.default_add_location_src_id,
-                    self.repair_id.picking_type_id.default_add_location_dest_id,
+                    res[1],
                 )
             elif (
                 repair_line_type == "remove"

--- a/repair_type/models/stock_picking_type.py
+++ b/repair_type/models/stock_picking_type.py
@@ -40,17 +40,6 @@ class PickingType(models.Model):
         help="This is the default add source location when you create a repair "
         "order with this operation type.",
     )
-    default_add_location_dest_id = fields.Many2one(
-        "stock.location",
-        "Default Add Destination Location",
-        compute="_compute_default_location_dest_id",
-        check_company=True,
-        store=True,
-        readonly=False,
-        precompute=True,
-        help="This is the default add destination location when you create a repair "
-        "order with this operation type.",
-    )
 
     @api.depends("code")
     def _compute_default_location_src_id(self):
@@ -59,20 +48,6 @@ class PickingType(models.Model):
             stock_location = picking_type.warehouse_id.lot_stock_id
             if picking_type.code == "repair_operation":
                 picking_type.default_add_location_src_id = stock_location.id
-        return res
-
-    @api.depends("code")
-    def _compute_default_location_dest_id(self):
-        res = super()._compute_default_location_dest_id()
-        for picking_type in self:
-            if picking_type.code == "repair_operation":
-                picking_type.default_add_location_dest_id = (
-                    picking_type.default_location_dest_id.id
-                )
-                picking_type.default_remove_location_src_id = (
-                    picking_type.default_location_dest_id.id
-                )
-                picking_type.default_recycle_location_src_id = (
-                    picking_type.default_location_dest_id.id
-                )
+                picking_type.default_remove_location_src_id = stock_location.id
+                picking_type.default_recycle_location_src_id = stock_location.id
         return res

--- a/repair_type/readme/DESCRIPTION.md
+++ b/repair_type/readme/DESCRIPTION.md
@@ -1,1 +1,1 @@
-This module adds the source location from removing and recycling components. If we select the both locations on stock picking type when you select that in a Repair Order, Odoo will automatically set that in stock moves for that components.
+This module adds support for source locations when adding, removing, or recycling components. If you specify any of these types in a Repair Order, Odoo will automatically apply the corresponding locations from the related stock picking type to the stock moves.

--- a/repair_type/readme/USAGE.md
+++ b/repair_type/readme/USAGE.md
@@ -1,2 +1,2 @@
-Set stock picking type for repairs and select source locations for removing and recycling components.
-Afterwards selecting that stock picking type on a Repair Order will automatically put that source location on stock moves of that components.
+- Set the stock picking type for repairs and define source locations for adding, removing and recycling components.
+- When you select this stock picking type in a Repair Order, Odoo will automatically assign the specified source locations to the stock moves for the respective components.

--- a/repair_type/static/description/index.html
+++ b/repair_type/static/description/index.html
@@ -370,10 +370,10 @@ ul.auto-toc {
 !! source digest: sha256:4bc94fb9082c60cda55c55f3f7a252f12eff375a752e9a1dc186d8345ddeeec0
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/repair/tree/17.0/repair_type"><img alt="OCA/repair" src="https://img.shields.io/badge/github-OCA%2Frepair-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/repair-17-0/repair-17-0-repair_type"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/repair&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module adds the source location from removing and recycling
-components. If we select the both locations on stock picking type when
-you select that in a Repair Order, Odoo will automatically set that in
-stock moves for that components.</p>
+<p>This module adds support for source locations when adding, removing, or
+recycling components. If you specify any of these types in a Repair
+Order, Odoo will automatically apply the corresponding locations from
+the related stock picking type to the stock moves.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.
@@ -395,10 +395,13 @@ Only for development or testing purpose, do not use in production.
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
-<p>Set stock picking type for repairs and select source locations for
-removing and recycling components. Afterwards selecting that stock
-picking type on a Repair Order will automatically put that source
-location on stock moves of that components.</p>
+<ul class="simple">
+<li>Set the stock picking type for repairs and define source locations
+for adding, removing and recycling components.</li>
+<li>When you select this stock picking type in a Repair Order, Odoo will
+automatically assign the specified source locations to the stock
+moves for the respective components.</li>
+</ul>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>

--- a/repair_type/views/stock_picking_type_views.xml
+++ b/repair_type/views/stock_picking_type_views.xml
@@ -5,21 +5,19 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="repair.repair_view_picking_type_form" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//field[@name='default_remove_location_dest_id']"
-                position="before"
-            >
+            <xpath expr="//field[@name='default_location_dest_id']" position="before">
                 <field
                     name="default_add_location_src_id"
                     options="{'no_create': True}"
                     invisible="code != 'repair_operation'"
                     required="code == 'repair_operation'"
-                /><field
-                    name="default_add_location_dest_id"
-                    options="{'no_create': True}"
-                    invisible="code != 'repair_operation'"
-                    required="code == 'repair_operation'"
                 />
+            </xpath>
+
+            <xpath
+                expr="//field[@name='default_remove_location_dest_id']"
+                position="before"
+            >
                 <field
                     name="default_remove_location_src_id"
                     options="{'no_create': True}"
@@ -27,6 +25,7 @@
                     required="code == 'repair_operation'"
                 />
             </xpath>
+
             <xpath
                 expr="//field[@name='default_recycle_location_dest_id']"
                 position="before"


### PR DESCRIPTION
The default 'Locations' for a Repair operation in Odoo core are as follows:

![imagen](https://github.com/user-attachments/assets/121fc993-2c5c-49b6-8857-988e88a5d0e8)

After some tests, I observed that the field '**Default Destination Location**' is misleading, as it doesn't correspond to the destination location of the repaired product. Instead, **it corresponds to the destination location of the added parts.**

This can be seen in the following clip:

https://github.com/user-attachments/assets/41282925-818a-4e55-9745-ac08bfc97db9

As we can see, the 'Pedal Bin' product is used as an added part to the repair order. The stock move that is being created transfers the product to 'Virtual Locations/Production', which corresponds to the 'Default Destination Location' field on the related stock picking type. On the other hand, the 'Customizable Desk' product is being sent back to 'WH/Stock', which corresponds to the 'Default Source Location' field.

In contrast, the 'Locations' for a Repair operation that are defined in this repair_type module are the following:

![imagen](https://github.com/user-attachments/assets/03c2c594-38a3-4884-8750-a0b12ad36831)

Basically, the new field 'Default Add Destination Location' overrides the functionality of the 'Default Destination Location' field. 

Therefore, the changes in this PR intend to remove this field. Additionally, the tests have been refactored to be more reusable.