### PR TITLE
[17.0][IMP] repair_picking_after_done: Implement auto-transfer functionality for completed repair orders

### DIFF
--- a/repair_picking_after_done/README.rst
+++ b/repair_picking_after_done/README.rst
@@ -28,8 +28,15 @@ Repair picking after done
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module adds the functionality to create transfer of repaired move
-once repair order is done.
+This module enhances Odoo's repair process by introducing automatic
+stock transfers for repaired products.
+
+-  **Automatic Transfer:** When a repair order is marked as done, a
+   stock transfer for the remaining repaired products is automatically
+   created and validated if the **auto_transfer_repair** parameter is
+   enabled.
+-  **Manual Transfer:** Users can manually create stock transfers when
+   automatic transfer is disabled.
 
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
@@ -44,14 +51,32 @@ once repair order is done.
 Configuration
 =============
 
-No configuration needed for this module.
+To enable automatic transfers for repaired products when a repair order
+is completed:
+
+-  Navigate to Repairs → Configuration → Settings.
+-  Enable the **Automatic Transfer on Repair Completion** setting.
+
+When enabled, internal transfers for repaired products are automatically
+created and validated upon completing the repair order.
 
 Usage
 =====
 
-After repair order is done, You will be able to see button "Transfer" on
-repair order's form view. You will be able to create internal transfer
-between repair location to any destination location.
+**Manual Transfers**
+
+1. After a repair order is marked as **Done**, a **Create Transfer**
+   button will appear on the repair order's form view.
+2. Click the Create Transfer button to create an internal transfer for
+   the repaired products.
+3. Specify the destination location and quantity to complete the
+   transfer.
+
+**Automatic Transfers**
+
+1. If the **auto_transfer_repair** configuration parameter is enabled,
+   an internal transfer is automatically created and validated when the
+   repair order is marked as **Done**.
 
 Known issues / Roadmap
 ======================

--- a/repair_picking_after_done/__manifest__.py
+++ b/repair_picking_after_done/__manifest__.py
@@ -8,10 +8,16 @@
     "website": "https://github.com/OCA/repair",
     "summary": "Transfer repaired move to another location directly from repair order",
     "category": "Repair",
-    "depends": ["repair_type", "repair_stock"],
+    "depends": [
+        "base_repair_config",
+        "repair_type",
+        "repair_stock",
+        "repair_type_product_destination",
+    ],
     "data": [
         "security/ir.model.access.csv",
         "views/repair.xml",
+        "views/res_config_settings_views.xml",
         "wizards/repair_move_transfer_views.xml",
     ],
     "installable": True,

--- a/repair_picking_after_done/i18n/ca.po
+++ b/repair_picking_after_done/i18n/ca.po
@@ -1,0 +1,158 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* repair_picking_after_done
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-12-11 13:39+0000\n"
+"PO-Revision-Date: 2024-12-11 13:39+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_res_config_settings__auto_transfer_repair
+msgid "Automatic Transfer on Repair Completion"
+msgstr "Transferència Automàtica en Compleció de Reparació"
+
+#. module: repair_picking_after_done
+#. odoo-python
+#: code:addons/repair_picking_after_done/models/repair.py:0
+#, python-format
+msgid ""
+"Automatic transfer cannot be completed because no product is specified for "
+"this repair order. Please ensure that a product is assigned to the repair "
+"order before proceeding with the transfer."
+msgstr ""
+"La transferència automàtica no es pot completar perquè no s'ha especificat un producte per "
+"aquesta ordre de reparació. Assegureu-vos que s'hagi assignat un producte a l'ordre de reparació "
+"abans de continuar amb la transferència."
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.res_config_settings_view_form_inherit
+msgid ""
+"Automatically create and validate stock transfers for completed repair "
+"orders."
+msgstr "Crear i validar automàticament les transferències d'estoc per a ordres de reparació completes."
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,help:repair_picking_after_done.field_res_config_settings__auto_transfer_repair
+msgid ""
+"Automatically create and validate transfers for repair orders upon "
+"completion."
+msgstr "Crear i validar automàticament les transferències per a les ordres de reparació en completar-les."
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.view_repair_move_transfer_wizard
+msgid "Cancel"
+msgstr "Cancel·lar"
+
+#. module: repair_picking_after_done
+#: model:ir.model,name:repair_picking_after_done.model_res_config_settings
+msgid "Config Settings"
+msgstr "Paràmetres de configuració"
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.repair_type_form_inherit
+msgid "Create Transfer"
+msgstr "Crear Transferència"
+
+#. module: repair_picking_after_done
+#: model:ir.model,name:repair_picking_after_done.model_repair_move_transfer
+msgid "Create an internal transfer from repaired moves"
+msgstr "Crear una transferència interna a partir dels moviments reparats"
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.view_repair_move_transfer_wizard
+msgid "Create transfer"
+msgstr "Crear transferència"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__create_uid
+msgid "Created by"
+msgstr "Creat per"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__create_date
+msgid "Created on"
+msgstr "Creat el"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__location_dest_id
+msgid "Destination location"
+msgstr "Ubicació de destí"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__display_name
+msgid "Display Name"
+msgstr "Nom a mostrar"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__id
+msgid "ID"
+msgstr "ID"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__write_uid
+msgid "Last Updated by"
+msgstr "Última actualització per"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__write_date
+msgid "Last Updated on"
+msgstr "Última actualització el"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__quantity
+msgid "Quantity to transfer"
+msgstr "Quantitat a transferir"
+
+#. module: repair_picking_after_done
+#. odoo-python
+#: code:addons/repair_picking_after_done/wizards/repair_move_transfer.py:0
+#: code:addons/repair_picking_after_done/wizards/repair_move_transfer.py:0
+#, python-format
+msgid ""
+"Quantity to transfer cannot exceed the remaining quantity in the repair "
+"order."
+msgstr ""
+"La quantitat a transferir no pot excedir la quantitat restant en l'ordre de reparació."
+
+#. module: repair_picking_after_done
+#. odoo-python
+#: code:addons/repair_picking_after_done/wizards/repair_move_transfer.py:0
+#: code:addons/repair_picking_after_done/wizards/repair_move_transfer.py:0
+#, python-format
+msgid "Quantity to transfer must be greater than 0."
+msgstr "La quantitat a transferir ha de ser superior a 0."
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__remaining_quantity
+msgid "Remaining Quantity to Transfer"
+msgstr "Quantitat restant a transferir"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_order__remaining_quantity
+msgid "Remaining quantity to be transferred"
+msgstr "Quantitat restant per transferir"
+
+#. module: repair_picking_after_done
+#: model:ir.model,name:repair_picking_after_done.model_repair_order
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__repair_order_id
+msgid "Repair Order"
+msgstr "Ordre de reparació"
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.view_repair_move_transfer_wizard
+msgid "Transfer Repaired Moves"
+msgstr "Transferir moviments reparats"
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.view_repair_move_transfer_wizard
+msgid "or"
+msgstr "o"

--- a/repair_picking_after_done/i18n/es.po
+++ b/repair_picking_after_done/i18n/es.po
@@ -1,0 +1,158 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* repair_picking_after_done
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-12-11 13:38+0000\n"
+"PO-Revision-Date: 2024-12-11 13:38+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_res_config_settings__auto_transfer_repair
+msgid "Automatic Transfer on Repair Completion"
+msgstr "Transferencia automática al completar la reparación"
+
+#. module: repair_picking_after_done
+#. odoo-python
+#: code:addons/repair_picking_after_done/models/repair.py:0
+#, python-format
+msgid ""
+"Automatic transfer cannot be completed because no product is specified for "
+"this repair order. Please ensure that a product is assigned to the repair "
+"order before proceeding with the transfer."
+msgstr ""
+"No se puede completar la transferencia automática porque no se ha especificado un producto para "
+"esta orden de reparación. Asegúrese de que un producto esté asignado a la orden de reparación antes "
+"de proceder con la transferencia."
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.res_config_settings_view_form_inherit
+msgid ""
+"Automatically create and validate stock transfers for completed repair "
+"orders."
+msgstr "Crear y validar automáticamente transferencias de stock para órdenes de reparación completadas."
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,help:repair_picking_after_done.field_res_config_settings__auto_transfer_repair
+msgid ""
+"Automatically create and validate transfers for repair orders upon "
+"completion."
+msgstr "Crear y validar automáticamente transferencias para órdenes de reparación al completarlas."
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.view_repair_move_transfer_wizard
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: repair_picking_after_done
+#: model:ir.model,name:repair_picking_after_done.model_res_config_settings
+msgid "Config Settings"
+msgstr "Ajustes de configuración"
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.repair_type_form_inherit
+msgid "Create Transfer"
+msgstr "Crear Transferencia"
+
+#. module: repair_picking_after_done
+#: model:ir.model,name:repair_picking_after_done.model_repair_move_transfer
+msgid "Create an internal transfer from repaired moves"
+msgstr "Crear una transferencia interna a partir de los movimientos reparados"
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.view_repair_move_transfer_wizard
+msgid "Create transfer"
+msgstr "Crear transferencia"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__location_dest_id
+msgid "Destination location"
+msgstr "Ubicación de destino"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__display_name
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__id
+msgid "ID"
+msgstr "ID"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__write_date
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__quantity
+msgid "Quantity to transfer"
+msgstr "Cantidad a transferir"
+
+#. module: repair_picking_after_done
+#. odoo-python
+#: code:addons/repair_picking_after_done/wizards/repair_move_transfer.py:0
+#: code:addons/repair_picking_after_done/wizards/repair_move_transfer.py:0
+#, python-format
+msgid ""
+"Quantity to transfer cannot exceed the remaining quantity in the repair "
+"order."
+msgstr ""
+"La cantidad a transferir no puede exceder la cantidad restante en la orden de reparación."
+
+#. module: repair_picking_after_done
+#. odoo-python
+#: code:addons/repair_picking_after_done/wizards/repair_move_transfer.py:0
+#: code:addons/repair_picking_after_done/wizards/repair_move_transfer.py:0
+#, python-format
+msgid "Quantity to transfer must be greater than 0."
+msgstr "La cantidad a transferir debe ser mayor que 0."
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__remaining_quantity
+msgid "Remaining Quantity to Transfer"
+msgstr "Cantidad restante a transferir"
+
+#. module: repair_picking_after_done
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_order__remaining_quantity
+msgid "Remaining quantity to be transferred"
+msgstr "Cantidad restante por transferir"
+
+#. module: repair_picking_after_done
+#: model:ir.model,name:repair_picking_after_done.model_repair_order
+#: model:ir.model.fields,field_description:repair_picking_after_done.field_repair_move_transfer__repair_order_id
+msgid "Repair Order"
+msgstr "Orden de reparación"
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.view_repair_move_transfer_wizard
+msgid "Transfer Repaired Moves"
+msgstr "Transferir movimientos reparados"
+
+#. module: repair_picking_after_done
+#: model_terms:ir.ui.view,arch_db:repair_picking_after_done.view_repair_move_transfer_wizard
+msgid "or"
+msgstr "o"

--- a/repair_picking_after_done/models/__init__.py
+++ b/repair_picking_after_done/models/__init__.py
@@ -1,1 +1,2 @@
 from . import repair
+from . import res_config_settings

--- a/repair_picking_after_done/models/res_config_settings.py
+++ b/repair_picking_after_done/models/res_config_settings.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Patryk Pyczko (APSL-Nagarro)<ppyczko@apsl.net>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    auto_transfer_repair = fields.Boolean(
+        "Automatic Transfer on Repair Completion",
+        config_parameter="repair.auto_transfer_repair",
+        help="Automatically create and validate transfers for "
+        "repair orders upon completion.",
+    )

--- a/repair_picking_after_done/readme/CONFIGURE.md
+++ b/repair_picking_after_done/readme/CONFIGURE.md
@@ -1,1 +1,6 @@
-No configuration needed for this module.
+To enable automatic transfers for repaired products when a repair order is completed:
+
+- Navigate to Repairs → Configuration → Settings.
+- Enable the **Automatic Transfer on Repair Completion** setting.
+
+When enabled, internal transfers for repaired products are automatically created and validated upon completing the repair order.

--- a/repair_picking_after_done/readme/DESCRIPTION.md
+++ b/repair_picking_after_done/readme/DESCRIPTION.md
@@ -1,2 +1,4 @@
-This module adds the functionality to create transfer of repaired move
-once repair order is done.
+This module enhances Odoo's repair process by introducing automatic stock transfers for repaired products.
+
+- **Automatic Transfer:** When a repair order is marked as done, a stock transfer for the remaining repaired products is automatically created and validated if the ***auto_transfer_repair*** parameter is enabled.
+- **Manual Transfer:** Users can manually create stock transfers when automatic transfer is disabled.

--- a/repair_picking_after_done/readme/USAGE.md
+++ b/repair_picking_after_done/readme/USAGE.md
@@ -1,3 +1,9 @@
-After repair order is done, You will be able to see button "Transfer" on
-repair order's form view. You will be able to create internal transfer
-between repair location to any destination location.
+**Manual Transfers**
+
+1. After a repair order is marked as **Done**, a **Create Transfer** button will appear on the repair order's form view.
+2. Click the Create Transfer button to create an internal transfer for the repaired products.
+3. Specify the destination location and quantity to complete the transfer.
+
+**Automatic Transfers**
+
+1. If the ***auto_transfer_repair*** configuration parameter is enabled, an internal transfer is automatically created and validated when the repair order is marked as **Done**.

--- a/repair_picking_after_done/static/description/index.html
+++ b/repair_picking_after_done/static/description/index.html
@@ -370,8 +370,16 @@ ul.auto-toc {
 !! source digest: sha256:f11fa65acd2414cbbab2c2c100e3d976b2147ad613787ffc494bc85e0242b0bd
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/repair/tree/17.0/repair_picking_after_done"><img alt="OCA/repair" src="https://img.shields.io/badge/github-OCA%2Frepair-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/repair-17-0/repair-17-0-repair_picking_after_done"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/repair&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module adds the functionality to create transfer of repaired move
-once repair order is done.</p>
+<p>This module enhances Odoo’s repair process by introducing automatic
+stock transfers for repaired products.</p>
+<ul class="simple">
+<li><strong>Automatic Transfer:</strong> When a repair order is marked as done, a
+stock transfer for the remaining repaired products is automatically
+created and validated if the <strong>auto_transfer_repair</strong> parameter is
+enabled.</li>
+<li><strong>Manual Transfer:</strong> Users can manually create stock transfers when
+automatic transfer is disabled.</li>
+</ul>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.
@@ -395,13 +403,32 @@ Only for development or testing purpose, do not use in production.
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
-<p>No configuration needed for this module.</p>
+<p>To enable automatic transfers for repaired products when a repair order
+is completed:</p>
+<ul class="simple">
+<li>Navigate to Repairs → Configuration → Settings.</li>
+<li>Enable the <strong>Automatic Transfer on Repair Completion</strong> setting.</li>
+</ul>
+<p>When enabled, internal transfers for repaired products are automatically
+created and validated upon completing the repair order.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
-<p>After repair order is done, You will be able to see button “Transfer” on
-repair order’s form view. You will be able to create internal transfer
-between repair location to any destination location.</p>
+<p><strong>Manual Transfers</strong></p>
+<ol class="arabic simple">
+<li>After a repair order is marked as <strong>Done</strong>, a <strong>Create Transfer</strong>
+button will appear on the repair order’s form view.</li>
+<li>Click the Create Transfer button to create an internal transfer for
+the repaired products.</li>
+<li>Specify the destination location and quantity to complete the
+transfer.</li>
+</ol>
+<p><strong>Automatic Transfers</strong></p>
+<ol class="arabic simple">
+<li>If the <strong>auto_transfer_repair</strong> configuration parameter is enabled,
+an internal transfer is automatically created and validated when the
+repair order is marked as <strong>Done</strong>.</li>
+</ol>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>

--- a/repair_picking_after_done/views/repair.xml
+++ b/repair_picking_after_done/views/repair.xml
@@ -11,7 +11,7 @@
                     name="action_transfer_done_moves"
                     string="Create Transfer"
                     type="object"
-                    invisible="state != 'done' or remaining_quantity == 0"
+                    invisible="state != 'done' or remaining_quantity == 0 or not product_id"
                 />
             </header>
         </field>

--- a/repair_picking_after_done/views/res_config_settings_views.xml
+++ b/repair_picking_after_done/views/res_config_settings_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+  <record id="res_config_settings_view_form_inherit" model="ir.ui.view">
+    <field name="name">res.config.settings.view.form.inherit.repair</field>
+    <field name="model">res.config.settings</field>
+    <field name="inherit_id" ref="base_repair_config.res_config_settings_view_form" />
+    <field name="arch" type="xml">
+      <xpath expr="//block[@name='repair_setting_container']" position="inside">
+        <setting
+                    id="auto_transfer_repair_setting"
+                    help="Automatically create and validate stock transfers for completed repair orders."
+                >
+          <field name="auto_transfer_repair" />
+        </setting>
+      </xpath>
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
This PR introduces the functionality to automatically create transfers for repaired products once a repair order is completed. This feature is controlled via the configuration setting repair.auto_transfer_repair.

cc https://github.com/APSL 160548

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review

Depends on:
- [base_repair_config] #69
- [repair_type_product_destination] #71