### PR TITLE
[15.0][FIX] repair_stock_move: On starting the repair do the confirmation of stock moves

### DIFF
--- a/repair_stock_move/models/repair_order.py
+++ b/repair_stock_move/models/repair_order.py
@@ -107,7 +107,7 @@ class RepairOrder(models.Model):
 
     def action_repair_start(self):
         res = super().action_repair_start()
-        self.mapped("stock_move_ids")._action_assign()
+        self.mapped("stock_move_ids")._action_confirm()
         return res
 
     def action_force_availability(self):


### PR DESCRIPTION
Do the confirmation of moves instead of direct assignment. It may happen that the stock moves are already confirmed without quantity reserved in the quant. This cause an error when trying to do the unreservation that is performed in the _action_assign. Doing the _action_confirm is safer because it does the reservation and then the assignment and in the assignment, when the reservation is made: https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_move_line.py#L388 the is no issues

If we don't do this, and the moves are confirmed without reservation, then you may end with this error:

![image](https://github.com/user-attachments/assets/e39cff90-7db2-4574-b07d-2b62674b6ab3)

cc @ForgeFlow
