### PR TITLE
[17.0][FIX] repair_type: default remove and recycle source locations

### DIFF
--- a/repair_type/models/stock_picking_type.py
+++ b/repair_type/models/stock_picking_type.py
@@ -48,6 +48,13 @@ class PickingType(models.Model):
             stock_location = picking_type.warehouse_id.lot_stock_id
             if picking_type.code == "repair_operation":
                 picking_type.default_add_location_src_id = stock_location.id
-                picking_type.default_remove_location_src_id = stock_location.id
-                picking_type.default_recycle_location_src_id = stock_location.id
+                prod_location = self.env["stock.location"].search(
+                    [
+                        ("usage", "=", "production"),
+                        ("company_id", "=", picking_type.company_id.id),
+                    ],
+                    limit=1,
+                )
+                picking_type.default_remove_location_src_id = prod_location.id
+                picking_type.default_recycle_location_src_id = prod_location.id
         return res


### PR DESCRIPTION
The default value for the source location of remove and recycle repair line types should be the production location. Because the components are removed from the repaired product and scrapped or put into stock respectively.

This also preserves standard Odoo behavior.

Below are the moves of a repair done with a vanilla runbot. The second line is of type "remove", third is "recyle" and last is "add".

![Screenshot from 2025-02-09 20-51-36](https://github.com/user-attachments/assets/49708eee-eaf0-47f4-817f-6cb6399c7db7)
