### PR TITLE
[17.0][IMP] repair_stock: use a non conflicting field for auxiliar transfers

### DIFF
--- a/repair_stock/models/__init__.py
+++ b/repair_stock/models/__init__.py
@@ -1,3 +1,5 @@
 # Copyright 2024 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from . import repair
+from . import stock_move
+from . import stock_rule

--- a/repair_stock/models/repair.py
+++ b/repair_stock/models/repair.py
@@ -27,9 +27,14 @@ class RepairOrder(models.Model):
 
     def _compute_picking_ids(self):
         for order in self:
+            # TODO: migration note: `repair_id` should not be used here
+            #  in v18, use `related_repair_id` instead while migrating
+            #  modules depending on this.
             moves = self.env["stock.move"].search(
                 [
+                    "|",
                     ("repair_id", "=", order.id),
+                    ("related_repair_id", "=", order.id),
                 ]
             )
             order.picking_ids = moves.mapped("picking_id")

--- a/repair_stock/models/stock_move.py
+++ b/repair_stock/models/stock_move.py
@@ -1,0 +1,19 @@
+# Copyright 2024 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    # `repair_id` is reserved to the stock.moves directly related
+    # to the execution of the repair order and has associated logic
+    # in odoo core code (like assigning the picking type)
+    # To avoid unexpected behaviors, we use `related_repair_id` to
+    # signal auxiliar stock moves that are not directly related to
+    # repair execution.
+    related_repair_id = fields.Many2one(
+        comodel_name="repair.order",
+        readonly=True,
+    )

--- a/repair_stock/models/stock_rule.py
+++ b/repair_stock/models/stock_rule.py
@@ -1,0 +1,15 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _get_custom_move_fields(self):
+        move_fields = super()._get_custom_move_fields()
+        move_fields += [
+            "related_repair_id",
+        ]
+        return move_fields

--- a/repair_stock/tests/test_stock_repair_order.py
+++ b/repair_stock/tests/test_stock_repair_order.py
@@ -102,7 +102,7 @@ class TestStockRepairOrder(common.TransactionCase):
                 "picking_type_id": self.warehouse.int_type_id.id,
                 "product_uom_qty": 1,
                 "product_uom": repair_order.product_id.uom_id.id,
-                "repair_id": repair_order.id,
+                "related_repair_id": repair_order.id,
             }
         )
         return picking
@@ -123,6 +123,7 @@ class TestStockRepairOrder(common.TransactionCase):
         repair_order._action_repair_confirm()
 
         picking = self._create_picking_and_move(repair_order)
+        self.assertEqual(picking.picking_type_id, self.warehouse.int_type_id)
         repair_order._compute_picking_ids()
 
         action = repair_order.action_view_pickings()


### PR DESCRIPTION
`repair_id` is reserved to the stock.moves directly related to the execution of the repair order and has associated logic in odoo core code (like assigning the picking type) To avoid unexpected behaviors, we use `related_repair_id` to signal auxiliar stock moves that are not directly related to repair execution.

To not break existing modules depending on it, support for `repair_id` is kept but it is recommended to remove in v18.