### PR TITLE
[17.0][IMP] repair_picking_after_done: hide Create Transfer Button

### DIFF
--- a/repair_picking_after_done/views/repair.xml
+++ b/repair_picking_after_done/views/repair.xml
@@ -11,7 +11,7 @@
                     name="action_transfer_done_moves"
                     string="Create Transfer"
                     type="object"
-                    invisible="state != 'done' or remaining_quantity == 0 or not product_id"
+                    invisible="state != 'done' or remaining_quantity &lt; 1 or not product_id"
                 />
             </header>
         </field>


### PR DESCRIPTION
As the remaining quantity can be negative, the condition to set the button invisible has to change to match this behavior.