### PR TITLE
[16.0][IMP] repair_quality_control: Auto-generate inspections

### DIFF
--- a/repair_quality_control/README.rst
+++ b/repair_quality_control/README.rst
@@ -29,8 +29,16 @@ Repair Quality Control
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module allows to create quality control inspections from repair
-order when that one is done. One repair order is linked to many
-different inspections.
+orders. One repair order can be linked to many different inspections.
+
+The related inspections can be created either on the confirmation of the
+repair order, or when it is done. The creation can be executed manually
+or automatically. Both of these aspects are configurable at a company
+level.
+
+Moreover, you can configure trigger lines at a Product, Product Template
+or Product Category level (using the 'Repair' trigger) to set the QC
+Test to use when creating the inspections.
 
 **Table of contents**
 
@@ -42,12 +50,31 @@ Usage
 
 To use this module, you need to:
 
+Configure the QC repair behavior for the company:
+
+1. Go to Settings > Repair.
+2. Configure the two settings related to QC Inspections.
+
+Configure the triggers:
+
+1. Go to Products > Products.
+2. Select a product (this product must then be used in a repair order).
+3. Go to the 'Inventory' tab.
+4. In the 'Quality Control' section, select the QC Test to use when
+   creating the inspections, for the 'Repair' trigger.
+
 Create a repair order:
 
 1. Go to Repairs > Repair Orders.
-2. Create new repair order and repair that.
-3. Create an inspection from the header button called "Create
-   Inspection".
+2. Create new repair order.
+3. Set the repair order to 'Done' or 'Confirmed' state.
+4. An inspection should be created automatically or a button should
+   appear to allow creating it manually.
+
+   -  The states where this should happen can slightly vary depending on
+      the Invoice Method of the repair order.
+   -  For example, when the Invoice Method is 'Before Repair', the order
+      never goes to 'Confirmed' state.
 
 You can access from repair order to inspection directly with a smart
 button and the same backwards.
@@ -73,9 +100,13 @@ Authors
 Contributors
 ------------
 
-- `APSL-Nagarro <https://www.apsl.tech>`__:
+-  `APSL-Nagarro <https://www.apsl.tech>`__:
 
-  - Antoni Marroig <amarroig@apsl.net>
+   -  Antoni Marroig <amarroig@apsl.net>
+
+-  `ForgeFlow <https://www.forgeflow.com>`__:
+
+   -  Laura Cazorla <laura.cazorla@forgeflow.com>
 
 Maintainers
 -----------

--- a/repair_quality_control/__manifest__.py
+++ b/repair_quality_control/__manifest__.py
@@ -12,10 +12,12 @@
     "application": False,
     "installable": True,
     "depends": [
-        "repair",
+        "base_repair_config",
         "quality_control_stock_oca",
     ],
     "data": [
+        "data/repair_quality_control_data.xml",
+        "views/res_config_settings_views.xml",
         "views/repair_views.xml",
         "views/qc_inspection_views.xml",
     ],

--- a/repair_quality_control/data/repair_quality_control_data.xml
+++ b/repair_quality_control/data/repair_quality_control_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2024 ForgeFlow, S.L.
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0) -->
+<odoo>
+    <record model="qc.trigger" id="qc_trigger_repair">
+        <field name="name">Repairs</field>
+        <field name="partner_selectable" eval="True" />
+        <field name="company_id" eval="False" />
+    </record>
+</odoo>

--- a/repair_quality_control/models/__init__.py
+++ b/repair_quality_control/models/__init__.py
@@ -2,3 +2,5 @@
 
 from . import qc_inspection
 from . import repair
+from . import res_company
+from . import res_config_settings

--- a/repair_quality_control/models/qc_inspection.py
+++ b/repair_quality_control/models/qc_inspection.py
@@ -1,13 +1,47 @@
 # Copyright 2024 Antoni Marroig(APSL-Nagarro)<amarroig@apsl.net>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class QcInspection(models.Model):
     _inherit = "qc.inspection"
 
-    repair_id = fields.Many2one("repair.order")
+    repair_id = fields.Many2one(
+        comodel_name="repair.order",
+        compute="_compute_repair_id",
+        store=True,
+    )
+
+    @api.depends("object_id")
+    def _compute_repair_id(self):
+        self.repair_id = False
+        for rec in self:
+            if rec.object_id and rec.object_id._name == "repair.order":
+                rec.repair_id = rec.object_id
+
+    @api.depends("object_id")
+    def _compute_product_id(self):
+        result = super()._compute_product_id()
+        self.product_id = False
+        for rec in self:
+            if rec.object_id and rec.object_id._name == "repair.order":
+                rec.product_id = rec.object_id.product_id
+        return result
+
+    @api.depends("object_id")
+    def _compute_lot(self):
+        result = super()._compute_lot()
+        self.lot_id = False
+        for rec in self:
+            if rec.object_id and rec.object_id._name == "repair.order":
+                rec.lot_id = rec.object_id.lot_id
+        return result
+
+    def object_selection_values(self):
+        objects = super().object_selection_values()
+        objects.append(("repair.order", "Repair Order"))
+        return objects
 
     def action_view_qc_repair_order(self):
         return {

--- a/repair_quality_control/models/repair.py
+++ b/repair_quality_control/models/repair.py
@@ -1,7 +1,9 @@
 # Copyright 2024 Antoni Marroig(APSL-Nagarro)<amarroig@apsl.net>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
+
+from odoo.addons.quality_control_oca.models.qc_trigger_line import _filter_trigger_lines
 
 
 class RepairOrder(models.Model):
@@ -13,6 +15,91 @@ class RepairOrder(models.Model):
         "Inspections",
     )
 
+    auto_generate_qc_inspection = fields.Boolean(
+        related="company_id.repair_auto_generate_qc_inspection",
+    )
+    generate_qc_inspection_state = fields.Selection(
+        related="company_id.repair_generate_qc_inspection_state",
+    )
+    show_button_create_qc_inspection = fields.Boolean(
+        compute="_compute_show_button_create_qc_inspection"
+    )
+
+    @api.depends(
+        "auto_generate_qc_inspection",
+        "generate_qc_inspection_state",
+        "state",
+        "invoice_method",
+    )
+    def _compute_show_button_create_qc_inspection(self):
+        self.show_button_create_qc_inspection = False
+        for repair in self.filtered(lambda r: not r.auto_generate_qc_inspection):
+            if repair.generate_qc_inspection_state == "confirmed":
+                if repair.state == "confirmed":
+                    self.show_button_create_qc_inspection = True
+                elif repair.state == "ready" and repair.invoice_method == "b4repair":
+                    self.show_button_create_qc_inspection = True
+            elif (
+                repair.generate_qc_inspection_state == "done" and repair.state == "done"
+            ):
+                self.show_button_create_qc_inspection = True
+
+    def create_qc_inspection(self):
+        self.ensure_one()
+        inspection_model = self.env["qc.inspection"].sudo()
+        qc_trigger = self.sudo().env.ref("repair_quality_control.qc_trigger_repair")
+        trigger_lines = set()
+        for model in [
+            "qc.trigger.product_category_line",
+            "qc.trigger.product_template_line",
+            "qc.trigger.product_line",
+        ]:
+            partner = self.partner_id if qc_trigger.partner_selectable else False
+            trigger_lines = trigger_lines.union(
+                self.env[model]
+                .sudo()
+                .get_trigger_line_for_product(
+                    qc_trigger, ["after"], self.product_id.sudo(), partner=partner
+                )
+            )
+        for trigger_line in _filter_trigger_lines(trigger_lines):
+            inspection_model._make_inspection(self, trigger_line)
+
+    def action_repair_confirm(self):
+        result = super().action_repair_confirm()
+        for rep in self:
+            auto_generate = rep.auto_generate_qc_inspection
+            if auto_generate and rep.generate_qc_inspection_state == "confirmed":
+                rep.create_qc_inspection()
+        return result
+
+    def action_repair_done(self):
+        result = super().action_repair_done()
+        for rep in self:
+            auto_generate = rep.auto_generate_qc_inspection
+            if auto_generate and rep.generate_qc_inspection_state == "done":
+                if rep.invoice_method != "after_repair":
+                    rep.create_qc_inspection()
+        return result
+
+    def action_repair_invoice_create(self):
+        result = super().action_repair_invoice_create()
+        for rep in self:
+            if rep.state == "done":
+                auto_generate = rep.auto_generate_qc_inspection
+                if auto_generate and rep.generate_qc_inspection_state == "done":
+                    if rep.invoice_method == "after_repair":
+                        rep.create_qc_inspection()
+        return result
+
+    def action_repair_cancel(self):
+        inspections = self.sudo().inspection_ids
+        draft_inspections = inspections.filtered(lambda i: i.state == "draft")
+        draft_inspections.unlink()
+        inspections -= draft_inspections
+        inspections.action_cancel()
+        return super().action_repair_cancel()
+
     def action_create_qc_inspection(self):
         self.ensure_one()
         action = self.env["ir.actions.act_window"]._for_xml_id(
@@ -22,14 +109,10 @@ class RepairOrder(models.Model):
         action["views"] = [(False, "form")]
         action["target"] = "current"
         action["name"] = _("Create Inspection")
-
         action["context"] = {
             "default_qty": self.product_qty,
-            "default_repair_id": self.id,
-            "default_object_id": f"product.product,{self.product_id.id}",
+            "default_object_id": f"repair.order,{self.id}",
         }
-        if self.lot_id:
-            action["context"]["default_object_id"] = f"stock.lot,{self.lot_id.id}"
         return action
 
     def action_view_repair_inspections(self):

--- a/repair_quality_control/models/res_company.py
+++ b/repair_quality_control/models/res_company.py
@@ -1,0 +1,26 @@
+# Copyright 2024 ForgeFlow (http://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    repair_auto_generate_qc_inspection = fields.Boolean(
+        string="Auto-generate QC Inspection",
+        help="If checked, QC Inspections will be automatically "
+        "created for Repair Order, on state changes.",
+    )
+
+    repair_generate_qc_inspection_state = fields.Selection(
+        [
+            ("confirmed", "On Confirm"),
+            ("done", "On Done"),
+        ],
+        string="Generate QC Inspection State",
+        default="done",
+        required=True,
+        help="This field allows you to select the state of the Repair "
+        "Order in which the QC Inspection will be generated.",
+    )

--- a/repair_quality_control/models/res_config_settings.py
+++ b/repair_quality_control/models/res_config_settings.py
@@ -1,0 +1,17 @@
+# Copyright 2024 ForgeFlow (http://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    repair_auto_generate_qc_inspection = fields.Boolean(
+        related="company_id.repair_auto_generate_qc_inspection",
+        readonly=False,
+    )
+    repair_generate_qc_inspection_state = fields.Selection(
+        related="company_id.repair_generate_qc_inspection_state",
+        readonly=False,
+    )

--- a/repair_quality_control/readme/CONTRIBUTORS.md
+++ b/repair_quality_control/readme/CONTRIBUTORS.md
@@ -1,2 +1,4 @@
 - [APSL-Nagarro](https://www.apsl.tech):
   - Antoni Marroig \<<amarroig@apsl.net>\>
+- [ForgeFlow](https://www.forgeflow.com):
+  - Laura Cazorla \<<laura.cazorla@forgeflow.com>\>

--- a/repair_quality_control/readme/DESCRIPTION.md
+++ b/repair_quality_control/readme/DESCRIPTION.md
@@ -1,2 +1,10 @@
-This module allows to create quality control inspections from repair order
-when that one is done. One repair order is linked to many different inspections.
+This module allows to create quality control inspections from repair orders.
+One repair order can be linked to many different inspections.
+
+The related inspections can be created either on the confirmation of the repair
+order, or when it is done. The creation can be executed manually or
+automatically. Both of these aspects are configurable at a company level.
+
+Moreover, you can configure trigger lines at a Product, Product Template or
+Product Category level (using the 'Repair' trigger) to set the QC Test to use
+when creating the inspections.

--- a/repair_quality_control/readme/USAGE.md
+++ b/repair_quality_control/readme/USAGE.md
@@ -1,10 +1,29 @@
 To use this module, you need to:
 
+Configure the QC repair behavior for the company:
+
+1.  Go to Settings > Repair.
+2.  Configure the two settings related to QC Inspections.
+
+Configure the triggers:
+
+1.  Go to Products > Products.
+2.  Select a product (this product must then be used in a repair order).
+3.  Go to the 'Inventory' tab.
+4.  In the 'Quality Control' section, select the QC Test to use when creating the
+    inspections, for the 'Repair' trigger.
+
 Create a repair order:
 
 1.  Go to Repairs > Repair Orders.
-2.  Create new repair order and repair that.
-3.  Create an inspection from the header button called "Create Inspection".
+2.  Create new repair order.
+3.  Set the repair order to 'Done' or 'Confirmed' state.
+4.  An inspection should be created automatically or a button should appear to
+    allow creating it manually.
+    * The states where this should happen can slightly vary depending on the
+      Invoice Method of the repair order.
+    * For example, when the Invoice Method is 'Before Repair', the order never
+      goes to 'Confirmed' state.
 
 You can access from repair order to inspection directly with a
 smart button and the same backwards.

--- a/repair_quality_control/static/description/index.html
+++ b/repair_quality_control/static/description/index.html
@@ -371,8 +371,14 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/repair/tree/16.0/repair_quality_control"><img alt="OCA/repair" src="https://img.shields.io/badge/github-OCA%2Frepair-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/repair-16-0/repair-16-0-repair_quality_control"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/repair&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module allows to create quality control inspections from repair
-order when that one is done. One repair order is linked to many
-different inspections.</p>
+orders. One repair order can be linked to many different inspections.</p>
+<p>The related inspections can be created either on the confirmation of the
+repair order, or when it is done. The creation can be executed manually
+or automatically. Both of these aspects are configurable at a company
+level.</p>
+<p>Moreover, you can configure trigger lines at a Product, Product Template
+or Product Category level (using the ‘Repair’ trigger) to set the QC
+Test to use when creating the inspections.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -389,12 +395,32 @@ different inspections.</p>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
 <p>To use this module, you need to:</p>
+<p>Configure the QC repair behavior for the company:</p>
+<ol class="arabic simple">
+<li>Go to Settings &gt; Repair.</li>
+<li>Configure the two settings related to QC Inspections.</li>
+</ol>
+<p>Configure the triggers:</p>
+<ol class="arabic simple">
+<li>Go to Products &gt; Products.</li>
+<li>Select a product (this product must then be used in a repair order).</li>
+<li>Go to the ‘Inventory’ tab.</li>
+<li>In the ‘Quality Control’ section, select the QC Test to use when
+creating the inspections, for the ‘Repair’ trigger.</li>
+</ol>
 <p>Create a repair order:</p>
 <ol class="arabic simple">
 <li>Go to Repairs &gt; Repair Orders.</li>
-<li>Create new repair order and repair that.</li>
-<li>Create an inspection from the header button called “Create
-Inspection”.</li>
+<li>Create new repair order.</li>
+<li>Set the repair order to ‘Done’ or ‘Confirmed’ state.</li>
+<li>An inspection should be created automatically or a button should
+appear to allow creating it manually.<ul>
+<li>The states where this should happen can slightly vary depending on
+the Invoice Method of the repair order.</li>
+<li>For example, when the Invoice Method is ‘Before Repair’, the order
+never goes to ‘Confirmed’ state.</li>
+</ul>
+</li>
 </ol>
 <p>You can access from repair order to inspection directly with a smart
 button and the same backwards.</p>
@@ -420,6 +446,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li><a class="reference external" href="https://www.apsl.tech">APSL-Nagarro</a>:<ul>
 <li>Antoni Marroig &lt;<a class="reference external" href="mailto:amarroig&#64;apsl.net">amarroig&#64;apsl.net</a>&gt;</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.forgeflow.com">ForgeFlow</a>:<ul>
+<li>Laura Cazorla &lt;<a class="reference external" href="mailto:laura.cazorla&#64;forgeflow.com">laura.cazorla&#64;forgeflow.com</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/repair_quality_control/tests/test_repair_quality_control.py
+++ b/repair_quality_control/tests/test_repair_quality_control.py
@@ -8,18 +8,88 @@ class RepairQualityControlTest(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.product_tmpl = cls.env.ref("product.product_product_27").product_tmpl_id
+        cls.product = cls.product_tmpl.product_variant_id
+        cls.test = cls.env.ref("quality_control_oca.qc_test_1")
+        cls.trigger = cls.env.ref("repair_quality_control.qc_trigger_repair")
+        cls.partner = cls.env.ref("base.res_partner_1")
         cls.repair_order = cls.env["repair.order"].create(
             {
-                "product_id": cls.env.ref("product.product_product_27").id,
+                "product_id": cls.product.id,
                 "lot_id": cls.env.ref("stock.lot_product_27").id,
+                "invoice_method": "none",
+                "partner_id": cls.partner.id,
             }
         )
+        cls.env.company.repair_auto_generate_qc_inspection = True
+        cls.env.company.repair_generate_qc_inspection_state = "confirmed"
 
-    def test_create_inspection_from_repair_order(self):
+    def test_qc_inspection_compute(self):
+        # Check that the repair_id, product_id and lot_id are not set
+        # since inspection does not have an object_id
+        inspect_form = Form(self.env["qc.inspection"])
+        qc_inspection = inspect_form.save()
+        self.assertFalse(qc_inspection.repair_id)
+        self.assertFalse(qc_inspection.product_id)
+        self.assertFalse(qc_inspection.lot_id)
+        # Set the object_id to a repair order and check that the
+        # repair_id, product_id and lot_id are set
+        qc_inspection.write({"object_id": f"repair.order,{self.repair_order.id}"})
+        self.assertEqual(qc_inspection.repair_id, self.repair_order)
+        self.assertEqual(qc_inspection.product_id, self.repair_order.product_id)
+        self.assertEqual(qc_inspection.lot_id, self.repair_order.lot_id)
+
+    def test_compute_show_button_create_qc_inspection(self):
+        # Show_button_create_qc_inspection is set to True
+        # on RO confirmation
+        self.env.company.repair_auto_generate_qc_inspection = False
+        self.env.company.repair_generate_qc_inspection_state = "confirmed"
+        self.repair_order.action_validate()
+        self.assertEqual(self.repair_order.state, "confirmed")
+        self.assertTrue(self.repair_order.show_button_create_qc_inspection)
+        # If we set the generate_qc_inspection_state to 'done'
+        # the button should not be shown anymore
+        self.env.company.repair_generate_qc_inspection_state = "done"
+        self.assertFalse(self.repair_order.show_button_create_qc_inspection)
+        # Now, the RO will be done and the button should be shown
+        # again
+        self.repair_order.action_repair_start()
+        self.repair_order.action_repair_end()
+        self.assertEqual(self.repair_order.state, "done")
+        self.assertTrue(self.repair_order.show_button_create_qc_inspection)
+        # If we auto generate the inspection, the button should never
+        # be shown
+        self.env.company.repair_auto_generate_qc_inspection = True
+        self.assertFalse(self.repair_order.show_button_create_qc_inspection)
+
+    def test_repair_cancel(self):
         inspect_form = Form(
             self.env["qc.inspection"].with_context(
-                default_repair_id=self.repair_order.id,
-                default_object_id=f"product.product,{self.repair_order.product_id.id}",
+                default_object_id=f"repair.order,{self.repair_order.id}",
+                default_test=False,
+            )
+        )
+        qc_inspection_1 = inspect_form.save()
+        qc_inspection_2 = qc_inspection_1.copy()
+        qc_inspection_1.test = self.env.ref("quality_control_oca.qc_test_1").id
+        qc_inspection_1.action_todo()
+        self.assertEqual(qc_inspection_1.state, "ready")
+        self.assertEqual(qc_inspection_2.state, "draft")
+        self.assertEqual(len(self.repair_order.inspection_ids), 2)
+        # After cancelling, the draft inspection should be deleted
+        # and the other one should be cancelled
+        self.repair_order.action_repair_cancel()
+        self.assertEqual(len(self.repair_order.inspection_ids), 1)
+        self.assertNotIn(self.repair_order.inspection_ids, qc_inspection_2)
+        self.assertIn(self.repair_order.inspection_ids, qc_inspection_1)
+        self.assertEqual(qc_inspection_1.state, "canceled")
+
+    def test_create_inspection_from_repair_order(self):
+        # Create an inspection from a repair order, with all the fields
+        # and check that the inspection is created accordingly
+        inspect_form = Form(
+            self.env["qc.inspection"].with_context(
+                default_object_id=f"repair.order,{self.repair_order.id}"
             )
         )
         qc_inspection = inspect_form.save()
@@ -27,11 +97,13 @@ class RepairQualityControlTest(TransactionCase):
         self.assertEqual(
             self.repair_order.inspection_ids.product_id, qc_inspection.product_id
         )
-        self.repair_order.lot_id = self.env.ref("stock.lot_product_27").id
+        self.assertEqual(self.repair_order.inspection_ids.lot_id, qc_inspection.lot_id)
+        # Create an inspection from a repair order, without the lot_id
+        # and check that the inspection is created accordingly
+        self.repair_order.lot_id = False
         inspect_form = Form(
             self.env["qc.inspection"].with_context(
-                default_repair_id=self.repair_order.id,
-                default_object_id=f"stock.lot,{self.repair_order.lot_id.id}",
+                default_object_id=f"repair.order,{self.repair_order.id}"
             )
         )
         qc_inspection = inspect_form.save()
@@ -39,6 +111,103 @@ class RepairQualityControlTest(TransactionCase):
         self.assertEqual(
             self.repair_order.inspection_ids[1].product_id, qc_inspection.product_id
         )
-        self.assertEqual(
+        self.assertFalse(
             self.repair_order.inspection_ids[1].lot_id, qc_inspection.lot_id
         )
+
+    def test_inspection_create_for_product(self):
+        # Create an inspection for a product and check that the inspection
+        # is created accordingly. It needs to be created on confirmation
+        self.product.qc_triggers = [
+            (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
+        ]
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)
+        self.repair_order.action_validate()
+        self.assertEqual(self.repair_order.state, "confirmed")
+        self.assertEqual(len(self.repair_order.inspection_ids), 1)
+        self.assertEqual(self.repair_order.inspection_ids.test, self.test)
+
+    def test_inspection_create_for_product_on_done(self):
+        # Create an inspection for a product and check that the inspection
+        # is created accordingly. It needs to be created on done
+        self.env.company.repair_generate_qc_inspection_state = "done"
+        self.product.qc_triggers = [
+            (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
+        ]
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)
+        self.repair_order.action_validate()
+        self.assertEqual(self.repair_order.state, "confirmed")
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)
+        self.repair_order.action_repair_start()
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)
+        self.repair_order.action_repair_end()
+        self.assertEqual(self.repair_order.state, "done")
+        self.assertEqual(len(self.repair_order.inspection_ids), 1)
+        self.assertEqual(self.repair_order.inspection_ids.test, self.test)
+
+    def test_inspection_no_create_for_product(self):
+        # Do not create an inspection since the company is not configured
+        # to auto generate inspections
+        self.env.company.repair_auto_generate_qc_inspection = False
+        self.product.qc_triggers = [
+            (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
+        ]
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)
+        self.repair_order.action_validate()
+        self.assertEqual(self.repair_order.state, "confirmed")
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)
+
+    def test_inspection_create_for_template(self):
+        self.product_tmpl.qc_triggers = [
+            (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
+        ]
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)
+        self.repair_order.action_validate()
+        self.assertEqual(len(self.repair_order.inspection_ids), 1)
+        self.assertEqual(self.repair_order.inspection_ids.test, self.test)
+
+    def test_inspection_create_for_category(self):
+        self.product.categ_id.qc_triggers = [
+            (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
+        ]
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)
+        self.repair_order.action_validate()
+        self.assertEqual(self.repair_order.state, "confirmed")
+        self.assertEqual(len(self.repair_order.inspection_ids), 1)
+        self.assertEqual(self.repair_order.inspection_ids.test, self.test)
+
+    def test_inspection_create_for_category_partner(self):
+        self.product.categ_id.qc_triggers = [
+            (
+                0,
+                0,
+                {
+                    "trigger": self.trigger.id,
+                    "test": self.test.id,
+                    "partners": self.partner.ids,
+                },
+            )
+        ]
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)
+        self.repair_order.action_validate()
+        self.assertEqual(self.repair_order.state, "confirmed")
+        self.assertEqual(len(self.repair_order.inspection_ids), 1)
+        self.assertEqual(self.repair_order.inspection_ids.test, self.test)
+
+    def test_inspection_create_for_category_wrong_partner(self):
+        wrong_partner = self.env.ref("base.res_partner_2")
+        self.product.categ_id.qc_triggers = [
+            (
+                0,
+                0,
+                {
+                    "trigger": self.trigger.id,
+                    "test": self.test.id,
+                    "partners": wrong_partner.ids,
+                },
+            )
+        ]
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)
+        self.repair_order.action_validate()
+        self.assertEqual(self.repair_order.state, "confirmed")
+        self.assertEqual(len(self.repair_order.inspection_ids), 0)

--- a/repair_quality_control/views/qc_inspection_views.xml
+++ b/repair_quality_control/views/qc_inspection_views.xml
@@ -8,18 +8,27 @@
         <field name="inherit_id" ref="quality_control_oca.qc_inspection_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//button[hasclass('oe_stat_button')]" position="before">
-                <field name="repair_id" readonly="1" invisible="1" />
+                <field
+                    name="repair_id"
+                    readonly="1"
+                    invisible="1"
+                    groups="stock.group_stock_user"
+                />
                 <button
                     class="oe_stat_button"
                     name="action_view_qc_repair_order"
                     type="object"
                     icon="fa-wrench"
                     attrs="{'invisible': [('repair_id', '=', False)]}"
+                    groups="stock.group_stock_user"
                 >
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_text">Repair order</span>
                     </div>
                 </button>
+            </xpath>
+            <xpath expr="//field[@name='lot_id']" position="before">
+                <field name="repair_id" readonly="1" groups="stock.group_stock_user" />
             </xpath>
         </field>
     </record>

--- a/repair_quality_control/views/repair_views.xml
+++ b/repair_quality_control/views/repair_views.xml
@@ -2,29 +2,38 @@
 <!-- # Copyright 2024 Antoni Marroig(APSL-Nagarro)<amarroig@apsl.net>
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
+
     <record id="view_repair_order_form_inherit" model="ir.ui.view">
         <field name="name">repair.order.form.inherit</field>
         <field name="model">repair.order</field>
         <field name="inherit_id" ref="repair.view_repair_order_form" />
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_validate']" position="before">
+                <field name="show_button_create_qc_inspection" invisible="1" />
                 <button
                     name="action_create_qc_inspection"
-                    attrs="{'invisible': [('state', '!=', 'done')]}"
+                    attrs="{'invisible': [('show_button_create_qc_inspection', '=', False)]}"
                     string="Create Inspection"
                     type="object"
                     class="oe_highlight"
                     data-hotkey="q"
+                    groups="quality_control_oca.group_quality_control_user"
                 />
             </xpath>
             <xpath expr="//button[@name='action_created_invoice']" position="after">
-                <field name="inspection_ids" readonly="1" invisible="1" />
+                <field
+                    name="inspection_ids"
+                    readonly="1"
+                    invisible="1"
+                    groups="quality_control_oca.group_quality_control_user"
+                />
                 <button
                     class="oe_stat_button"
                     name="action_view_repair_inspections"
                     type="object"
                     icon="fa-list-ul"
                     attrs="{'invisible': [('inspection_ids', '=', [])]}"
+                    groups="quality_control_oca.group_quality_control_user"
                 >
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_text">Inspections</span>
@@ -33,4 +42,5 @@
             </xpath>
         </field>
     </record>
+
 </odoo>

--- a/repair_quality_control/views/res_config_settings_views.xml
+++ b/repair_quality_control/views/res_config_settings_views.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.repair</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="5" />
+        <field
+            name="inherit_id"
+            ref="base_repair_config.res_config_settings_view_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='repair_setting_container']" position="inside">
+                <div class="col-lg-6 o_setting_box" id="auto_generate_qc_inspection">
+                    <div class="o_setting_left_pane">
+                        <field name="repair_auto_generate_qc_inspection" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="repair_auto_generate_qc_inspection" />
+                        <div
+                            class="text-muted"
+                        >If checked, QC Inspections will be automatically created for Repair Order, on state changes</div>
+                    </div>
+                </div>
+                <div class="col-lg-6 o_setting_box" id="generate_qc_inspection_state">
+                    <div class="o_setting_left_pane" />
+                    <div class="o_setting_right_pane">
+                        <label for="repair_generate_qc_inspection_state" />
+                        <div
+                            class="text-muted"
+                        >This field allows you to select the state of the Repair Order in which the QC Inspection will be generated</div>
+                        <div class="mt8">
+                            <field
+                                name="repair_generate_qc_inspection_state"
+                                class="o_light_label"
+                                widget="radio"
+                                required="True"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo-addon-base_repair_config@git+https://github.com/ForgeFlow/repair.git@16.0-bck-base_repair_config#subdirectory=setup/base_repair_config


### PR DESCRIPTION
Allow to create QC inspections automatically on confirmation or finalization of repair orders, while also keeping the possibility to generate them manually through the button. For more details, refer to the module's README.

This PR depends on #99.