### PR TITLE
[15.0][IMP] repair_stock_move: do not assign lot if the product of the move does not match the product of the lot

### DIFF
--- a/repair_stock_move/models/stock_move.py
+++ b/repair_stock_move/models/stock_move.py
@@ -62,6 +62,10 @@ class StockMove(models.Model):
         )
         if self.repair_line_id and self.repair_line_id.lot_id:
             vals["lot_id"] = self.repair_line_id.lot_id.id
-        elif self.repair_id and self.repair_id.lot_id:
+        elif (
+            self.repair_id
+            and self.repair_id.lot_id
+            and self.product_id == self.repair_id.product_id
+        ):
             vals["lot_id"] = self.repair_id.lot_id.id
         return vals


### PR DESCRIPTION
We can have stock moves that do not relate the main product or the componennts used for repairs, for example:
- refurbish process
- warranty expenses
- products send to the cusotmer for their own repair but not linked to a repair line

We cannot reproduce the error directly with the current code but you can have more stock moves related to the repair in some other module that solves the use cases above. This improvement is not harmful for the normal use case.