### PR TITLE
[16.0][IMP] repair_quality_control: create repair from inspection

### DIFF
--- a/repair_quality_control/models/qc_inspection.py
+++ b/repair_quality_control/models/qc_inspection.py
@@ -16,3 +16,17 @@ class QcInspection(models.Model):
             "res_model": "repair.order",
             "res_id": self.repair_id.id,
         }
+
+    def action_repair(self):
+        self.ensure_one()
+        if self.picking_id:
+            action = self.picking_id.action_repair_return()
+            action["context"].update(
+                {
+                    "default_product_id": self.product_id.id,
+                    "default_lot_id": self.lot_id.id,
+                    "default_move_id": self.object_id.id,
+                    "default_inspection_ids": [self.id],
+                }
+            )
+            return action

--- a/repair_quality_control/models/repair.py
+++ b/repair_quality_control/models/repair.py
@@ -26,10 +26,10 @@ class RepairOrder(models.Model):
         action["context"] = {
             "default_qty": self.product_qty,
             "default_repair_id": self.id,
-            "default_object_id": f"product.product,{self.product_id.id}",
+            "default_object_id": f"product.product, {self.product_id.id}",
         }
         if self.lot_id:
-            action["context"]["default_object_id"] = f"stock.lot,{self.lot_id.id}"
+            action["context"]["default_object_id"] = f"stock.lot, {self.lot_id.id}"
         return action
 
     def action_view_repair_inspections(self):

--- a/repair_quality_control/tests/test_repair_quality_control.py
+++ b/repair_quality_control/tests/test_repair_quality_control.py
@@ -8,10 +8,14 @@ class RepairQualityControlTest(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        cls.product = cls.env.ref("product.product_product_27")
+        cls.lot = cls.env.ref("stock.lot_product_27")
+
         cls.repair_order = cls.env["repair.order"].create(
             {
-                "product_id": cls.env.ref("product.product_product_27").id,
-                "lot_id": cls.env.ref("stock.lot_product_27").id,
+                "product_id": cls.product.id,
+                "lot_id": cls.lot.id,
             }
         )
 
@@ -19,7 +23,7 @@ class RepairQualityControlTest(TransactionCase):
         inspect_form = Form(
             self.env["qc.inspection"].with_context(
                 default_repair_id=self.repair_order.id,
-                default_object_id=f"product.product,{self.repair_order.product_id.id}",
+                default_object_id=f"product.product, {self.repair_order.product_id.id}",
             )
         )
         qc_inspection = inspect_form.save()
@@ -31,7 +35,7 @@ class RepairQualityControlTest(TransactionCase):
         inspect_form = Form(
             self.env["qc.inspection"].with_context(
                 default_repair_id=self.repair_order.id,
-                default_object_id=f"stock.lot,{self.repair_order.lot_id.id}",
+                default_object_id=f"stock.lot, {self.repair_order.lot_id.id}",
             )
         )
         qc_inspection = inspect_form.save()
@@ -42,3 +46,39 @@ class RepairQualityControlTest(TransactionCase):
         self.assertEqual(
             self.repair_order.inspection_ids[1].lot_id, qc_inspection.lot_id
         )
+
+    def test_create_repair_order_from_inspection(self):
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.env.ref("stock.picking_type_in").id,
+                "location_id": self.env.ref("stock.stock_location_customers").id,
+                "location_dest_id": self.env.ref("stock.stock_location_stock").id,
+            }
+        )
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test Move",
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.product.uom_id.id,
+                "picking_id": picking.id,
+                "location_id": picking.location_id.id,
+                "location_dest_id": picking.location_dest_id.id,
+            }
+        )
+        qc_inspection = self.env["qc.inspection"].create(
+            {
+                "picking_id": picking.id,
+                "object_id": f"stock.move, {move.id}",
+                "product_id": self.product.id,
+                "lot_id": self.lot.id,
+            }
+        )
+        repair = qc_inspection.action_repair()
+        repair_form = Form(
+            self.env[(repair.get("res_model"))].with_context(**repair["context"])
+        )
+        repair = repair_form.save()
+        self.assertEqual(repair.move_id, move)
+        self.assertEqual(repair.lot_id, qc_inspection.lot_id)
+        self.assertEqual(repair.product_id, qc_inspection.product_id)

--- a/repair_quality_control/views/qc_inspection_views.xml
+++ b/repair_quality_control/views/qc_inspection_views.xml
@@ -21,6 +21,15 @@
                     </div>
                 </button>
             </xpath>
+            <xpath expr="//header" position="inside">
+                <button
+                    name="action_repair"
+                    string="Repair"
+                    type="object"
+                    class="oe_highlight"
+                    attrs="{'invisible': ['|', ('state', 'not in', ['waiting', 'failed']), ('picking_id', '=', False)]}"
+                />
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/repair_quality_control/views/repair_views.xml
+++ b/repair_quality_control/views/repair_views.xml
@@ -18,13 +18,19 @@
                 />
             </xpath>
             <xpath expr="//button[@name='action_created_invoice']" position="after">
-                <field name="inspection_ids" readonly="1" invisible="1" />
+                <field
+                    name="inspection_ids"
+                    readonly="1"
+                    invisible="1"
+                    groups="quality_control_oca.group_quality_control_user"
+                />
                 <button
                     class="oe_stat_button"
                     name="action_view_repair_inspections"
                     type="object"
                     icon="fa-list-ul"
                     attrs="{'invisible': [('inspection_ids', '=', [])]}"
+                    groups="quality_control_oca.group_quality_control_user"
                 >
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_text">Inspections</span>


### PR DESCRIPTION
Add the possibility to create a repair order from an inspection directly. 

Also, fix read access for group_quality_control_user in view.