### PR TITLE
[15.0][FIX] repair_refurbish_repair_stock_move: change refurbish product in the middle of the repair

### DIFF
--- a/repair_refurbish_repair_stock_move/models/repair_order.py
+++ b/repair_refurbish_repair_stock_move/models/repair_order.py
@@ -24,7 +24,10 @@ class RepairOrder(models.Model):
     def write(self, values):
         res = super().write(values)
         for repair in self:
-            if "to_refurbish" in values.keys():
+            if (
+                "to_refurbish" in values.keys()
+                or "refurbish_product_id" in values.keys()
+            ):
                 if repair.mapped("stock_move_ids") and repair.state not in (
                     "draft",
                     "done",

--- a/repair_refurbish_repair_stock_move/tests/test_repair_refurbish.py
+++ b/repair_refurbish_repair_stock_move/tests/test_repair_refurbish.py
@@ -138,3 +138,39 @@ class TestMrpMtoWithStock(TransactionCase):
             ]
         )
         self.assertEqual(moves.lot_id, existing_lot_refurbish)
+
+    def test_03_change_refurbish_product_when_repairing(self):
+        # Create the repair with to_refurbish=True from the beginning
+        repair = self.repair_obj.create(
+            {
+                "product_id": self.product.id,
+                "product_qty": 3.0,
+                "product_uom": self.product.uom_id.id,
+                "location_dest_id": self.customer_location.id,
+                "location_id": self.stock_location_stock.id,
+                "to_refurbish": True,
+                "refurbish_product_id": self.refurbish_product.id,
+                "refurbish_location_dest_id": self.customer_location.id,
+            }
+        )
+        repair.action_validate()
+        repair.action_repair_start()
+
+        # Now change refurbish_product_id
+        another_refurbish_product = self.product_obj.create(
+            {"name": "Refurbished Screen 2", "type": "product"}
+        )
+        repair.write(
+            {
+                "refurbish_product_id": another_refurbish_product.id,
+            }
+        )
+        repair.action_repair_end()
+        moves = self.move_line_obj.search(
+            [
+                ("move_id.reference", "=", repair.name),
+                ("state", "!=", "cancel"),
+                ("product_id", "=", another_refurbish_product.id),
+            ]
+        )
+        self.assertEqual(len(moves), 1)


### PR DESCRIPTION
When the refurbish product is changed in the middle of the repair the stock moves kept the original refurbished product, this is not correct, the stock moves has to be recreated. Short demonstration:


https://github.com/user-attachments/assets/e2113ec6-19dc-4029-8796-9e68e78c8c88

