### PR TITLE
[18.0][ADD] repair_service: add description field on services

### DIFF
--- a/repair_service/models/repair_service.py
+++ b/repair_service/models/repair_service.py
@@ -35,6 +35,10 @@ class RepairService(models.Model):
         "Quantity", digits="Product Unit of Measure", required=True, default=1.0
     )
     company_id = fields.Many2one(related="repair_id.company_id")
+    description = fields.Text(
+        string="Service Description",
+        help="Custom description that will be transferred to the sale order line.",
+    )
 
     @api.depends("product_id")
     def _compute_name(self):
@@ -54,6 +58,8 @@ class RepairService(models.Model):
             "product_uom_qty": product_qty,
             "product_uom": self.product_uom.id,
         }
+        if self.description:
+            vals["name"] = self.description
         if self.repair_id.under_warranty:
             vals["price_unit"] = 0.0
         elif self.product_id.lst_price:

--- a/repair_service/tests/test_repair_service.py
+++ b/repair_service/tests/test_repair_service.py
@@ -101,3 +101,19 @@ class TestRepairOrderFlow(TransactionCase):
 
         # Check that the sale order line has the correct price unit
         self.assertEqual(sale_order_line.price_unit, self.service_product.lst_price)
+
+    def test_04_action_create_sale_order_with_description(self):
+        # Set a custom description on the repair service
+        self.repair_service.description = "Custom repair description"
+
+        # Create a sale order from the repair order
+        self.repair_order.action_create_sale_order()
+
+        # Check that the sale order line exists for the service product
+        sale_order_line = self.repair_order.sale_order_id.order_line.filtered(
+            lambda line: line.product_id == self.service_product
+        )
+        self.assertTrue(sale_order_line)
+
+        # Check that the description was transferred to the sale order line
+        self.assertEqual(sale_order_line.name, "Custom repair description")

--- a/repair_service/views/repair_views.xml
+++ b/repair_service/views/repair_views.xml
@@ -13,7 +13,7 @@
                     >
                         <list editable="bottom">
                             <field name="product_id" />
-                            <field name="display_name" />
+                            <field name="description" />
                             <field
                                 name="product_uom_category_id"
                                 column_invisible="True"


### PR DESCRIPTION
Added a custom description field on repair services that is editable in the Services tab of a repair order. The description is transferred to the related sale order line when a quotation is created.

Also added a test to ensure the description is properly propagated.

Task: 4970