### PR TITLE
[18.0][IMP] repair_service: allow user to use a custom description

### DIFF
--- a/repair_service/models/repair_service.py
+++ b/repair_service/models/repair_service.py
@@ -14,7 +14,8 @@ class RepairService(models.Model):
     display_name = fields.Text(
         "Description",
         required=True,
-        compute="_compute_name",
+        compute="_compute_display_name",
+        inverse="_inverse_display_name",
         store=True,
         precompute=True,
     )
@@ -37,9 +38,13 @@ class RepairService(models.Model):
     company_id = fields.Many2one(related="repair_id.company_id")
 
     @api.depends("product_id")
-    def _compute_name(self):
+    def _compute_display_name(self):
         for service in self:
             service.display_name = service.product_id.name
+
+    def _inverse_display_name(self):
+        # Do nothing, just avoid the compute to overwrite user values
+        return
 
     @api.depends("product_id")
     def _compute_product_uom(self):

--- a/repair_service/views/repair_views.xml
+++ b/repair_service/views/repair_views.xml
@@ -13,7 +13,10 @@
                     >
                         <list editable="bottom">
                             <field name="product_id" />
-                            <field name="display_name" />
+                            <field
+                                name="display_name"
+                                readonly="repair_id.state in ('cancel', 'done')"
+                            />
                             <field
                                 name="product_uom_category_id"
                                 column_invisible="True"


### PR DESCRIPTION
In versions <17 the description was editable when the repair was not done:

<img width="490" height="243" alt="image" src="https://github.com/user-attachments/assets/5bd5d3c1-4daa-45cb-a1b9-613e770c3fbd" />


I think we should let the user to use a custom description.