### PR TITLE
[18.0][IMP] repair_service: copy display_name to sale.order.line

### DIFF
--- a/repair_service/models/repair_service.py
+++ b/repair_service/models/repair_service.py
@@ -58,7 +58,9 @@ class RepairService(models.Model):
             "product_id": self.product_id.id,
             "product_uom_qty": product_qty,
             "product_uom": self.product_uom.id,
+            "name": self.display_name,
         }
+
         if self.repair_id.under_warranty:
             vals["price_unit"] = 0.0
         elif self.product_id.lst_price:

--- a/repair_service/tests/test_repair_service.py
+++ b/repair_service/tests/test_repair_service.py
@@ -101,3 +101,19 @@ class TestRepairOrderFlow(TransactionCase):
 
         # Check that the sale order line has the correct price unit
         self.assertEqual(sale_order_line.price_unit, self.service_product.lst_price)
+
+    def test_04_copy_display_name_to_sale_order_line(self):
+        # Set a custom description on the repair service
+        self.repair_service.display_name = "Custom service description"
+
+        # Create a sale order from the repair order
+        self.repair_order.action_create_sale_order()
+
+        # Check that the sale order line exists for the service product
+        sale_order_line = self.repair_order.sale_order_id.order_line.filtered(
+            lambda line: line.product_id == self.service_product
+        )
+        self.assertTrue(sale_order_line)
+
+        # Check that the description was copied into the sale order line name
+        self.assertEqual(sale_order_line.name, "Custom service description")


### PR DESCRIPTION
Ensure that the repair service description (display_name) is transferred to the sale order line when creating a quotation. This improves consistency between repair services and generated sales documents.

Task: 4970