### PR TITLE
[18.0] [FIX] repair_order_template: fix domains

### DIFF
--- a/repair_order_template/models/repair_order_template.py
+++ b/repair_order_template/models/repair_order_template.py
@@ -18,10 +18,7 @@ class RepairOrderTemplate(models.Model):
     product_id = fields.Many2one(
         "product.product",
         string="Product to Repair",
-        domain=[
-            ("type", "in", ["product", "consu"]),
-            ("company_id", "in", [False, company_id]),
-        ],
+        domain=[("type", "=", "consu")],
         check_company=True,
     )
     line_ids = fields.One2many(

--- a/repair_order_template/models/repair_order_template_line.py
+++ b/repair_order_template/models/repair_order_template_line.py
@@ -30,10 +30,7 @@ class RepairOrderTemplateLine(models.Model):
     product_id = fields.Many2one(
         "product.product",
         string="Product",
-        domain=[
-            ("type", "in", ["product", "consu"]),
-            ("company_id", "in", [False, company_id]),
-        ],
+        domain=[("type", "=", "consu")],
         check_company=True,
         required=True,
     )
@@ -43,7 +40,7 @@ class RepairOrderTemplateLine(models.Model):
     product_uom = fields.Many2one(
         "uom.uom",
         string="Unit of Measure",
-        domain=[("category_id", "=", product_uom_category_id)],
+        domain="[('category_id', '=', product_uom_category_id)]",
         compute="_compute_product_uom",
         readonly=False,
         required=True,


### PR DESCRIPTION
There were 2 errors with this domain, resulting from the Migration to 18.0:

1. The "product" type was removed in Odoo, becoming simply a "consu" with `is_storable` set to True. Thus, this leaf can be simplified.

2. The domain attribute was changed from a string to a list, causing the dynamic evaluation of `company_id` to fail. Moreover, this leaf is no longer needed in 18.0 since `check_company=True` will automatically add better ones.

Traceback mentioned above:

```
  File "/odoo/src/odoo/addons/product/models/product_product.py", line 576, in name_search
    return super().name_search(name, args, operator, limit)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/models.py", line 1892, in name_search
    records = self.search_fetch(domain, ['display_name'], limit=limit)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/models.py", line 1781, in search_fetch
    return self._fetch_query(query, fields_to_fetch)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/models.py", line 4240, in _fetch_query
    rows = self.env.execute_query(query.select(*sql_terms))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/odoo/api.py", line 993, in execute_query
    self.cr.execute(query)
  File "/odoo/src/odoo/odoo/sql_db.py", line 357, in execute
    res = self._obj.execute(query, params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type integer: "repair.order.template.company_id"
LINE 1: ...roduct_product__product_tmpl_id"."company_id" IN ('repair.or...
```