### PR TITLE
[18.0][FIX] repair_order_group: keep groups only for draft duplicates

### DIFF
--- a/repair_order_group/models/repair_order.py
+++ b/repair_order_group/models/repair_order.py
@@ -43,6 +43,19 @@ class RepairOrder(models.Model):
                 continue
             repair.grouped_repair_ids = repair.group_id.repair_ids - repair
 
+    def copy(self, default=None):
+        """Keep the group only for draft repairs when duplicating.
+
+        Duplicating a grouped repair order:
+        - if original is in Draft -> duplicated repair stays in the same group
+        - otherwise -> duplicated repair is not assigned to any group
+        """
+        self.ensure_one()
+        default = dict(default or {})
+        if self.group_id and self.state != "draft":
+            default["group_id"] = False
+        return super().copy(default)
+
     def action_add_another_repair(self):
         """Create a new empty repair linked to the same group.
 

--- a/repair_order_group/models/repair_order.py
+++ b/repair_order_group/models/repair_order.py
@@ -67,6 +67,19 @@ class RepairOrder(models.Model):
                 continue
             repair.grouped_repair_ids = repair.group_id.repair_ids - repair
 
+    def copy(self, default=None):
+        """Keep the group only for draft repairs when duplicating.
+
+        Duplicating a grouped repair order:
+        - if original is in Draft -> duplicated repair stays in the same group
+        - otherwise -> duplicated repair is not assigned to any group
+        """
+        self.ensure_one()
+        default = dict(default or {})
+        if self.group_id and self.state != "draft":
+            default["group_id"] = False
+        return super().copy(default)
+
     def action_add_another_repair(self):
         """Create a new empty repair linked to the same group.
 

--- a/repair_order_group/models/repair_order.py
+++ b/repair_order_group/models/repair_order.py
@@ -24,7 +24,7 @@ class RepairOrder(models.Model):
         check_company=True,
         index=True,
         readonly=True,
-        copy=False,
+        copy=True,
         help="Repairs sharing the same group can be processed and quoted together.",
     )
 

--- a/repair_order_group/tests/test_repair_order_group.py
+++ b/repair_order_group/tests/test_repair_order_group.py
@@ -659,3 +659,60 @@ class TestRepairOrderGroup(TransactionCase):
 
         repair.action_repair_cancel()
         self.assertEqual(repair.state, "cancel")
+
+    def test_22_duplicate_grouped_repair_keeps_group_in_draft(self):
+        """Draft repair duplication keeps the same group."""
+        group = self.env["repair.order.group"].create({"partner_id": self.partner.id})
+        repair = self.env["repair.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": self.picking_type.id,
+                "product_id": self.product.id,
+                "group_id": group.id,
+            }
+        )
+
+        self.env["repair.service"].create(
+            {
+                "repair_id": repair.id,
+                "product_id": self.product.id,
+            }
+        )
+
+        duplicated = repair.copy()
+
+        self.assertEqual(
+            duplicated.group_id,
+            repair.group_id,
+            "Draft grouped repair should remain in the same group when duplicated.",
+        )
+
+    def test_23_duplicate_grouped_repair_drops_group_outside_draft(self):
+        """Non-draft repair duplication must not keep the group."""
+        group = self.env["repair.order.group"].create({"partner_id": self.partner.id})
+        repair = self.env["repair.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": self.picking_type.id,
+                "product_id": self.product.id,
+                "group_id": group.id,
+            }
+        )
+
+        self.env["repair.service"].create(
+            {
+                "repair_id": repair.id,
+                "product_id": self.product.id,
+            }
+        )
+
+        repair.action_validate()
+        repair._action_repair_confirm()
+
+        duplicated = repair.copy()
+
+        self.assertFalse(
+            duplicated.group_id,
+            "Non-draft grouped repair should not be assigned "
+            "to a group when duplicated.",
+        )

--- a/repair_order_group/tests/test_repair_order_group.py
+++ b/repair_order_group/tests/test_repair_order_group.py
@@ -984,18 +984,11 @@ class TestRepairOrderGroup(TransactionCase):
             }
         )
 
-        self.env["repair.service"].create(
-            {
-                "repair_id": repair.id,
-                "product_id": self.product.id,
-            }
-        )
-
         duplicated = repair.copy()
 
         self.assertEqual(
             duplicated.group_id,
-            repair.group_id,
+            group,
             "Draft grouped repair should remain in the same group when duplicated.",
         )
 
@@ -1011,13 +1004,6 @@ class TestRepairOrderGroup(TransactionCase):
             }
         )
 
-        self.env["repair.service"].create(
-            {
-                "repair_id": repair.id,
-                "product_id": self.product.id,
-            }
-        )
-
         repair.action_validate()
         repair._action_repair_confirm()
 
@@ -1025,6 +1011,6 @@ class TestRepairOrderGroup(TransactionCase):
 
         self.assertFalse(
             duplicated.group_id,
-            "Non-draft grouped repair should not be assigned "
-            "to a group when duplicated.",
+            "Non-draft grouped repair should not remain in a repair group "
+            "when duplicated.",
         )

--- a/repair_order_group/tests/test_repair_order_group.py
+++ b/repair_order_group/tests/test_repair_order_group.py
@@ -971,3 +971,60 @@ class TestRepairOrderGroup(TransactionCase):
         self.assertIn("Several open sale orders", str(error.exception))
         self.assertIn(repair_1.name, str(error.exception))
         self.assertIn(repair_2.name, str(error.exception))
+
+    def test_37_duplicate_grouped_repair_keeps_group_in_draft(self):
+        """Draft repair duplication keeps the same group."""
+        group = self.env["repair.order.group"].create({"partner_id": self.partner.id})
+        repair = self.env["repair.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": self.picking_type.id,
+                "product_id": self.product.id,
+                "group_id": group.id,
+            }
+        )
+
+        self.env["repair.service"].create(
+            {
+                "repair_id": repair.id,
+                "product_id": self.product.id,
+            }
+        )
+
+        duplicated = repair.copy()
+
+        self.assertEqual(
+            duplicated.group_id,
+            repair.group_id,
+            "Draft grouped repair should remain in the same group when duplicated.",
+        )
+
+    def test_38_duplicate_grouped_repair_drops_group_outside_draft(self):
+        """Non-draft repair duplication must not keep the group."""
+        group = self.env["repair.order.group"].create({"partner_id": self.partner.id})
+        repair = self.env["repair.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": self.picking_type.id,
+                "product_id": self.product.id,
+                "group_id": group.id,
+            }
+        )
+
+        self.env["repair.service"].create(
+            {
+                "repair_id": repair.id,
+                "product_id": self.product.id,
+            }
+        )
+
+        repair.action_validate()
+        repair._action_repair_confirm()
+
+        duplicated = repair.copy()
+
+        self.assertFalse(
+            duplicated.group_id,
+            "Non-draft grouped repair should not be assigned "
+            "to a group when duplicated.",
+        )


### PR DESCRIPTION
Duplicating grouped repairs after draft can unintentionally keep them tied to the original group, mixing operational flows and shared quotations. Restrict group propagation to draft repairs to match expected usage.

Task: 5252