### PR TITLE
[18.0][FIX] repair_order_group: prevent repair copy from inheriting group

### DIFF
--- a/repair_order_group/models/repair_order.py
+++ b/repair_order_group/models/repair_order.py
@@ -24,6 +24,7 @@ class RepairOrder(models.Model):
         check_company=True,
         index=True,
         readonly=True,
+        copy=False,
         help="Repairs sharing the same group can be processed and quoted together.",
     )
 


### PR DESCRIPTION
Duplicating a grouped repair caused the copy to join the original group, merging unrelated repairs into the same sale order.

Task: 5312