### PR TITLE
[18.0][FIX] repair_analytic_timesheet: keep timesheet date and UoM on analytic lines

### DIFF
--- a/repair_analytic_timesheet/models/repair_order.py
+++ b/repair_analytic_timesheet/models/repair_order.py
@@ -43,8 +43,9 @@ class RepairOrder(models.Model):
             vals_list.append(
                 {
                     "name": self.name,
-                    "date": fields.Date.context_today(self),
+                    "date": timesheet.date,
                     "unit_amount": timesheet.unit_amount,
+                    "product_uom_id": timesheet.product_uom_id.id,
                     "amount": timesheet.amount * float(percentage) / 100.0,
                     "employee_id": timesheet.employee_id.id
                     if timesheet.employee_id

--- a/repair_analytic_timesheet/tests/test_repair_analytic_timesheet.py
+++ b/repair_analytic_timesheet/tests/test_repair_analytic_timesheet.py
@@ -51,7 +51,7 @@ class TestRepairAnalyticDistributionTimesheet(TransactionCase):
             }
         )
 
-    def _add_timesheet(self, repair, project, hours=2.0):
+    def _add_timesheet(self, repair, project, hours=2.0, date=None):
         """`amount` is not settable directly: hr_timesheet recomputes it
         from `unit_amount * employee_id.hourly_cost` on create/write
         (see `hr_timesheet.models.hr_timesheet._timesheet_postprocess_values`),
@@ -66,6 +66,7 @@ class TestRepairAnalyticDistributionTimesheet(TransactionCase):
                 "employee_id": self.employee.id,
                 "unit_amount": hours,
                 "company_id": repair.company_id.id,
+                **({"date": date} if date else {}),
             }
         )
 
@@ -229,3 +230,39 @@ class TestRepairAnalyticDistributionTimesheet(TransactionCase):
 
         action = repair.action_view_analytic_lines()
         self.assertIn(("project_id", "=", False), action["domain"])
+
+    def test_distribution_line_keeps_timesheet_date(self):
+        """The distribution line must be booked on the date the work was
+        done, not on the date the repair happened to be completed.
+        Otherwise the cost lands in the wrong accounting period whenever
+        a repair spans a period boundary."""
+        repair = self._make_repair()
+        timesheet = self._add_timesheet(
+            repair, self.project_spread, hours=2.0, date="2024-01-15"
+        )
+        self._complete_repair(repair)
+
+        lines = self._distribution_lines(repair)
+        self.assertTrue(lines)
+        self.assertEqual(
+            lines.mapped("date"),
+            [timesheet.date] * len(lines),
+            "Distribution line must inherit the timesheet date.",
+        )
+
+    def test_distribution_line_keeps_timesheet_uom(self):
+        """unit_amount is a number of hours, so the line must carry the
+        timesheet's UoM; without it the quantity is unitless and analytic
+        reports cannot aggregate it."""
+        repair = self._make_repair()
+        timesheet = self._add_timesheet(repair, self.project_spread, hours=2.0)
+        self._complete_repair(repair)
+
+        lines = self._distribution_lines(repair)
+        self.assertTrue(lines)
+        self.assertTrue(timesheet.product_uom_id)
+        self.assertEqual(
+            lines.product_uom_id,
+            timesheet.product_uom_id,
+            "Distribution line must inherit the timesheet UoM.",
+        )


### PR DESCRIPTION
@Escodoo 

[SO747-32]

cc @WesleyOliveira98 @douglascstd @CristianoMafraJunior @marcelsavegnago @pedrobaeza 

Analytic lines generated from repair timesheets were built with `fields.Date.context_today()` and no UoM.

Two consequences:

- The line was booked on the **repair completion date** instead of the date the work was done, moving the cost to the wrong accounting period whenever a repair spans a period boundary.
- `unit_amount` is a number of hours, but the line carried no `product_uom_id`, so analytic reports could not aggregate it.

Both values are now taken from the timesheet (`timesheet.date`, `timesheet.product_uom_id`), consistent with how core `stock_account` fills `product_uom_id` on analytic lines.
